### PR TITLE
[WIP] Implement SO_REUSEPORT

### DIFF
--- a/crystal/kemal/src/server.cr
+++ b/crystal/kemal/src/server.cr
@@ -3,6 +3,7 @@ require "kemal"
 Kemal.config do |cfg|
 	cfg.serve_static = false
 	cfg.logging = false
+	cfg.env = "production"
 end
 
 get "/" do |env|
@@ -18,4 +19,4 @@ post "/user" do |env|
 end
 
 Kemal.config.env = "production"
-Kemal.run
+Kemal.run { |cfg| cfg.server.not_nil!.listen("0.0.0.0",3000, reuse_port: true) }

--- a/crystal/kemal/src/server.cr
+++ b/crystal/kemal/src/server.cr
@@ -19,4 +19,6 @@ post "/user" do |env|
 end
 
 Kemal.config.env = "production"
-Kemal.run { |cfg| cfg.server.not_nil!.listen("0.0.0.0",3000, reuse_port: true) }
+Kemal.run do |cfg|
+  cfg.server.not_nil!.bind_tcp("0.0.0.0", 3000, reuse_port: true)
+end

--- a/crystal/raze/src/server.cr
+++ b/crystal/raze/src/server.cr
@@ -14,4 +14,5 @@ end
 
 Raze.config.port = 3000
 Raze.config.env = "production"
+Raze.config.reuse_port = true
 Raze.run

--- a/php/laravel/Dockerfile
+++ b/php/laravel/Dockerfile
@@ -47,7 +47,7 @@ RUN rm -fr /usr/local/etc/php-fpm.d/zz-docker.conf
 
 RUN echo 'server {\n\
     root /usr/src/app/public;\n\
-    listen 0.0.0.0:3000;\n\
+    listen 0.0.0.0:3000 reuseport;\n\
     location / {\n\
         fastcgi_pass unix:/var/run/php-fpm.sock;\n\
         fastcgi_param   SCRIPT_FILENAME         $document_root/index.php;\n\

--- a/php/symfony/Dockerfile
+++ b/php/symfony/Dockerfile
@@ -33,7 +33,7 @@ RUN php bin/console cache:warmup
 
 RUN echo 'server {\n\
     root /usr/src/app/public;\n\
-    listen 0.0.0.0:3000;\n\
+    listen 0.0.0.0:3000 reuseport;\n\
     location / {\n\
         fastcgi_pass unix:/var/run/php-fpm.sock;\n\
         fastcgi_param   SCRIPT_FILENAME         $document_root/index.php;\n\

--- a/ruby/hanami/apps/web/controllers/home/user.rb
+++ b/ruby/hanami/apps/web/controllers/home/user.rb
@@ -3,7 +3,7 @@ module Web::Controllers::Home
     include Web::Action
 
     def call(params)
-      params[:id]
+      self.body = params[:id]
     end
   end
 end


### PR DESCRIPTION
Hi,

This `PR` implements **SO_REUSEPORT**.

+ java
   + [x] act
+ nim
   + [ ] jester @dom96
+ c
   + [ ] kore @jorisvink
   + [ ] agoo-c @ohler55
+ rust
   + [ ] nickel @nickel-org
   + [ ] iron @iron
   + [ ] rocket @SergioBenitez
   + [ ] actix-web @actix
   + [ ] gotham @gotham-rs
+ ruby
   + [x] sinatra
   + [x] rack-routing
   + [x] hanami
   + [x] agoo
   + [x] roda
   + [x] flame
   + [x] rails
+ objc
   + [ ] criollo @thecatalinstan
+ node
   + [x] foxify
   + [x] turbo_polka
   + [x] fastify
   + [x] hapi
   + [x] muneem
   + [x] restify
   + [x] polka
   + [x] rayo
   + [x] koa
   + [x] restana
   + [x] express
+ scala
   + [ ] akkahttp @akka
   + [ ] http4s
+ cpp
   + [x] evhtp
+ go
   + [ ] muxie
   + [ ] iris
   + [ ] gorilla-mux
   + [ ] gin
   + [ ] beego
   + [ ] echo
   + [ ] chi
   + [ ] fasthttprouter
   + [ ] gf
+ csharp
   + [ ] aspnetcore
+ elixir
   + [x] plug
   + [x] phoenix
+ swift
   + [ ] perfect
   + [ ] kitura
   + [ ] vapor
+ php
   + [ ] zend-framework
   + [ ] zend-expressive
   + [ ] slim
   + [ ] symfony
   + [ ] laravel
   + [ ] lumen
+ crystal
   + [x] onyx
   + [x] spider-gazelle
   + [ ] raze
   + [ ] amber
   + [x] kemal
   + [x] router.cr
   + [x] orion
   + [x] lucky
+ python
   + [x] japronto
   + [x] flask
   + [x] falcon
   + [x] responder
   + [x] cyclone
   + [x] starlette
   + [x] django
   + [x] sanic
   + [x] bottle
   + [x] tornado
   + [x] aiohttp
   + [x] vibora
   + [x] quart
   + [ ] quart

@OvermindDL1 This feature **COULD** be enabled on each framework https://github.com/tbrand/which_is_the_fastest/issues/69

Regards,

PS : Only `kemal` as in **WIP**

https://github.com/kemalcr/kemal/issues/459