### PR TITLE
Use separated crystal version for each framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ flame:
 	docker build -t flame ruby/flame
 
 # --- Crystal ---
-crystal: kemal router.cr lucky amber spider-gazelle
+crystal: kemal router.cr amber spider-gazelle # lucky
 
 # Kemal
 kemal:

--- a/crystal/amber/config/environments/development.yml
+++ b/crystal/amber/config/environments/development.yml
@@ -7,8 +7,6 @@ logging:
   filter:
     - password
     - confirm_password
-  skip:
-    -
   context:
     - request
     - session

--- a/crystal/amber/config/environments/production.yml
+++ b/crystal/amber/config/environments/production.yml
@@ -1,0 +1,30 @@
+secret_key_base: VuYrJ2n2SFsZ6QFa56a1LNQQYdLcaHjMzfhFgjCChvQ
+port: 3000
+name: amber
+logging:
+  severity: debug
+  colorize: true
+  filter:
+    - password
+    - confirm_password
+  context:
+    - request
+    - session
+    - headers
+    - cookies
+    - params
+
+host: 0.0.0.0
+port_reuse: true
+process_count: 1
+# ssl_key_file:
+# ssl_cert_file:
+redis_url: "redis://localhost:6379"
+database_url: postgres://postgres:@localhost:5432/amber_development
+session:
+  key: amber.session
+  store: signed_cookie
+  expires: 0
+
+secrets:
+  description: Store your development secrets credentials and settings here.

--- a/crystal/amber/config/environments/test.yml
+++ b/crystal/amber/config/environments/test.yml
@@ -7,8 +7,6 @@ logging:
   filter:
     - password
     - confirm_password
-  skip:
-    -
   context:
     - request
     - session

--- a/crystal/amber/shard.yml
+++ b/crystal/amber/shard.yml
@@ -16,4 +16,4 @@ targets:
 dependencies:
   amber:
     github: amberframework/amber
-    version: 0.8.0
+    version: ~> 0.9.0

--- a/crystal/lucky/Dockerfile
+++ b/crystal/lucky/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal
+FROM crystallang/crystal:0.25.1
 
 WORKDIR /usr/src/app
 

--- a/crystal/raze/Dockerfile
+++ b/crystal/raze/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal
+FROM crystallang/crystal:0.25.1
 
 WORKDIR /usr/src/app
 
@@ -7,4 +7,5 @@ COPY src src
 
 RUN shards build --release --no-debug
 
+EXPOSE 3000
 CMD bin/server

--- a/crystal/raze/shard.yml
+++ b/crystal/raze/shard.yml
@@ -11,7 +11,7 @@ targets:
 dependencies:
   raze:
     github: samueleaton/raze
-    version: ~> 0.2.1
+    version: ~> 0.3.0
 
 crystal: 0.24.2
 

--- a/crystal/raze/src/server.cr
+++ b/crystal/raze/src/server.cr
@@ -12,6 +12,7 @@ post "/user" do |ctx|
   nil
 end
 
+Raze.config.logging = false
 Raze.config.port = 3000
 Raze.config.env = "production"
 Raze.run

--- a/crystal/spider-gazelle/Dockerfile
+++ b/crystal/spider-gazelle/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal
+FROM crystallang/crystal:0.25.1
 
 WORKDIR /usr/src/app
 

--- a/crystal/spider-gazelle/shard.yml
+++ b/crystal/spider-gazelle/shard.yml
@@ -4,7 +4,7 @@ version: 1.0.0
 dependencies:
   action-controller:
     github: spider-gazelle/action-controller
-    version: ~> 1.0.1
+    version: ~> 1.0.5
 
 targets:
   app:

--- a/neph.yaml
+++ b/neph.yaml
@@ -20,7 +20,8 @@ crystal:
     - router.cr
     - amber
     - kemal
-    #- lucky
+    - raze
+    - lucky
     - spider-gazelle
 
 ruby:

--- a/neph.yaml
+++ b/neph.yaml
@@ -20,7 +20,7 @@ crystal:
     - router.cr
     - amber
     - kemal
-    - lucky
+    #- lucky
     - spider-gazelle
 
 ruby:

--- a/tools/src/benchmarker.cr
+++ b/tools/src/benchmarker.cr
@@ -57,6 +57,7 @@ LANGS = [
   {lang: "crystal", targets: [
     {name: "kemal", repo: "kemalcr/kemal"},
     {name: "router.cr", repo: "tbrand/router.cr"},
+    {name: "raze", repo: "samueleaton/raze" },
     {name: "amber", repo: "amberframework/amber"},
     {name: "lucky", repo: "luckyframework/lucky"},
     {name: "spider-gazelle", repo: "spider-gazelle/spider-gazelle"},

--- a/tools/src/benchmarker.cr
+++ b/tools/src/benchmarker.cr
@@ -58,7 +58,7 @@ LANGS = [
     {name: "kemal", repo: "kemalcr/kemal"},
     {name: "router.cr", repo: "tbrand/router.cr"},
     {name: "amber", repo: "amberframework/amber"},
-    #{name: "lucky", repo: "luckyframework/lucky"},
+    {name: "lucky", repo: "luckyframework/lucky"},
     {name: "spider-gazelle", repo: "spider-gazelle/spider-gazelle"},
   ]},
   {lang: "go", targets: [

--- a/tools/src/benchmarker.cr
+++ b/tools/src/benchmarker.cr
@@ -58,7 +58,7 @@ LANGS = [
     {name: "kemal", repo: "kemalcr/kemal"},
     {name: "router.cr", repo: "tbrand/router.cr"},
     {name: "amber", repo: "amberframework/amber"},
-    {name: "lucky", repo: "luckyframework/lucky"},
+    #{name: "lucky", repo: "luckyframework/lucky"},
     {name: "spider-gazelle", repo: "spider-gazelle/spider-gazelle"},
   ]},
   {lang: "go", targets: [


### PR DESCRIPTION
Hi,

`crystal` has been release in **0.26**.

This release introduce breaking changes, https://github.com/crystal-lang/crystal/blob/master/CHANGELOG.md#0261-2018-08-27

This `PR` upgrade `amber` since compatibility has been fixed by community

Thanks @robacarp and all `amber` **community** :tada:

Regards,