### PR TITLE
Set hanami in production

### DIFF
--- a/ruby/hanami/Dockerfile
+++ b/ruby/hanami/Dockerfile
@@ -6,6 +6,8 @@ COPY Gemfile config.ru ./
 COPY apps apps
 COPY config config
 
+ENV HANAMI_ENV production
+
 RUN bundle install
 
 EXPOSE 3000


### PR DESCRIPTION
Hi,

`hanami` was running on `default` _environment_ (**development**)

This `PR` turn `hanami` into **production**

Thanks @jodosha (#273)

Regards,