### PR TITLE
fix: forget to add prism on ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
     - FRAMEWORK=raze
     - FRAMEWORK=kemal
     - FRAMEWORK=spider-gazelle
+    - FRAMEWORK=prism
     - FRAMEWORK=lucky
     - FRAMEWORK=amber
     - FRAMEWORK=router.cr


### PR DESCRIPTION
Hi,

Following the #340, this `PR` add `prism` to **CI**

Regards,