### PR TITLE
Use pypi version of japronto

### DIFF
--- a/python/japronto/requirements.txt
+++ b/python/japronto/requirements.txt
@@ -1,1 +1,2 @@
--e git+https://github.com/squeaky-pl/japronto.git#egg=japronto
+japronto==0.1.*
+uvloop==0.8.1


### PR DESCRIPTION
Hi,

This  `PR` upgrade `japronto` to **0.1.1** instead of using **master**

However, I need to fix `uvloop` to **0.8.1**, @see https://github.com/squeaky-pl/japronto/issues/122

Thanks @codenoid for your work :tada: 

Regards,