### PR TITLE
scala/akkahttp: Running outside of sbt

### DIFF
--- a/scala/akkahttp/Dockerfile
+++ b/scala/akkahttp/Dockerfile
@@ -10,4 +10,4 @@ RUN sbt assembly
 
 EXPOSE 3000
 
-CMD sbt run
+CMD java -jar target/scala-2.12/server_scala_akkahttp


### PR DESCRIPTION
I don't understand why `sbt run` is used though the uberjar is created via the `assembly` command.