### PR TITLE
Use stderr instead of file

### DIFF
--- a/tools/pipeline.lua
+++ b/tools/pipeline.lua
@@ -17,7 +17,6 @@
 -- percentile : 99.999
   
 done = function(summary, latency, requests)
-  file = io.open('/tmp/which_is_the_fastest.out', 'w')
 
   out = {
     summary.duration,
@@ -41,10 +40,9 @@ done = function(summary, latency, requests)
 
   for key, value in pairs(out) do
     if key > 1 then
-      file:write(",")
+      io.stderr:write(",")
     end
-    file:write(string.format("%d", value))
+    io.stderr:write(string.format("%d", value))
   end
 
-  file.close(file)
 end

--- a/tools/pipeline_post.lua
+++ b/tools/pipeline_post.lua
@@ -21,7 +21,6 @@ wrk.headers["Content-Type"] = "application/x-www-form-urlencoded"
 -- percentile : 99.999
   
 done = function(summary, latency, requests)
-  file = io.open('/tmp/which_is_the_fastest.out', 'w')
 
   out = {
     summary.duration,
@@ -45,10 +44,9 @@ done = function(summary, latency, requests)
 
   for key, value in pairs(out) do
     if key > 1 then
-      file:write(",")
+      io.stderr:write(",")
     end
-    file:write(string.format("%d", value))
+    io.stderr:write(string.format("%d", value))
   end
 
-  file.close(file)
 end

--- a/tools/src/client.cr
+++ b/tools/src/client.cr
@@ -39,13 +39,14 @@ class Client
 
   def run
     if @method == "POST"
-      `wrk -H 'Connection: keep-alive' --latency -d #{@duration}s -s #{PIPELINE_POST} -c #{@connections.to_i} --timeout 8 -t #{@threads} #{@url}`
+      command = "wrk -H 'Connection: keep-alive' --latency -d #{@duration}s -s #{PIPELINE_POST} -c #{@connections.to_i} --timeout 8 -t #{@threads} #{@url}"
     else
-      `wrk -H 'Connection: keep-alive' --latency -d #{@duration}s -s #{PIPELINE_GET} -c #{@connections.to_i} --timeout 8 -t #{@threads} #{@url}`
+      command = "wrk -H 'Connection: keep-alive' --latency -d #{@duration}s -s #{PIPELINE_GET} -c #{@connections.to_i} --timeout 8 -t #{@threads} #{@url}"
     end
+    io = IO::Memory.new
+    Process.run(command, shell: true, error: io)
 
-    result = File.read("/tmp/which_is_the_fastest.out").split(",")
-    File.delete("/tmp/which_is_the_fastest.out")
+    result = io.to_s.split(",")
 
     data = JSON.build do |json|
       json.object do


### PR DESCRIPTION
Hi,

Benchmark results (`wrk` results) are written in file, and this one is parsed as CSV.

To simplify process, it will be convenient to use stderr (memory) to write this CSV.

Regards,