### PR TITLE
Fix php builds

### DIFF
--- a/php/laravel/Dockerfile
+++ b/php/laravel/Dockerfile
@@ -19,7 +19,7 @@ ENV APP_ENV production
 ENV APP_DEBUG false
 ENV APP_KEY base64:txfHNf/SOo222Rm8I39Urb9SmvUy+nuAF98t/ukF0lk=
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 RUN composer install --no-dev --prefer-dist --classmap-authoritative
 RUN composer dumpautoload -o
 

--- a/php/symfony/Dockerfile
+++ b/php/symfony/Dockerfile
@@ -13,7 +13,7 @@ COPY config config
 COPY public public
 COPY bin bin
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 RUN composer install --no-dev --prefer-dist --classmap-authoritative
 
 RUN sed -i 's/\;prefix.*/prefix = \/usr\/src\/app\/public/g' /usr/local/etc/php-fpm.d/www.conf


### PR DESCRIPTION
Hi,

`php` based framework could break the build process due to failure in `composer` installation.

Regards,