### PR TITLE
Switch Quart ASGI server to Uvicorn and disable logging

### DIFF
--- a/python/quart/Dockerfile
+++ b/python/quart/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 3000
 
-CMD hypercorn --bind 0.0.0.0:3000 --workers $(nproc) server:app
+CMD uvicorn --host 0.0.0.0 --port 3000 --no-access-log server:app

--- a/python/quart/requirements.txt
+++ b/python/quart/requirements.txt
@@ -1,2 +1,2 @@
 quart==0.6.*
-hypercorn
+uvicorn


### PR DESCRIPTION
As this is a HTTP/1 benchmarking exercise Uvicorn is sufficient and
faster than Hypercorn. Note that Uvicorn does not, as yet, support
multiple workers.

As logging seems to be disabled in other projects, it should be here
as it makes a large difference to the performance.