### PR TITLE
update jester to 0.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
     - FRAMEWORK=quart
     - FRAMEWORK=cyclone
     - FRAMEWORK=mofuw
+    - FRAMEWORK=jester
     - FRAMEWORK=act
     - FRAMEWORK=rails
     - FRAMEWORK=rack-routing
@@ -35,6 +36,7 @@ env:
     - FRAMEWORK=raze
     - FRAMEWORK=kemal
     - FRAMEWORK=spider-gazelle
+    - FRAMEWORK=prism
     - FRAMEWORK=lucky
     - FRAMEWORK=amber
     - FRAMEWORK=router.cr

--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -99,9 +99,9 @@ crystal:
     website: spider-gazelle.net
     version: "1.1"
 nim:
-  # jester:
-  #   github: dom96/jester
-  #   version: "0.4"
+  jester:
+    github: dom96/jester
+    version: "0.4"
   mofuw:
     github: 2vg/mofuw
     version: "2.0"
@@ -147,13 +147,13 @@ rust:
   rocket:
     website: rocket.rs
     version: "0.3"
-# elixir:
-#   phoenix:
-#     website: phoenixframework.org
-#     version: "1.3"
-#   plug:
-#     github: elixir-plug/plug
-#     version: "1.6"
+#elixir:
+#  phoenix:
+#    website: phoenixframework.org
+#    version: "1.3"
+#  plug:
+#    github: elixir-plug/plug
+#    version: "1.6"
 cpp:
   evhtp:
     github: criticalstack/libevhtp

--- a/nim/jester/Dockerfile
+++ b/nim/jester/Dockerfile
@@ -1,4 +1,4 @@
-FROM nimlang/nim
+FROM nimlang/nim:0.19.0
 
 WORKDIR /usr/src/app
 

--- a/nim/jester/Dockerfile
+++ b/nim/jester/Dockerfile
@@ -1,17 +1,10 @@
-FROM gcc:latest
-
-RUN apt update && apt install -y libgc-dev
-
-ENV CHOOSENIM_NO_ANALYTICS 1
-ENV CHOOSENIM_CHOOSE_VERSION #0c683d28bbd5
-RUN curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
-ENV PATH $PATH:/root/.nimble/bin
+FROM nimlang/nim
 
 WORKDIR /usr/src/app
 
 COPY server_nim_jester.nim server_nim_jester.nimble ./
 
-RUN nimble install -y httpbeast@#v0.2.0
+RUN nimble install -y httpbeast@#v0.2.1
 RUN nimble c -d:release --threads:on -y server_nim_jester.nim
 
 CMD ./server_nim_jester

--- a/nim/jester/server_nim_jester.nimble
+++ b/nim/jester/server_nim_jester.nimble
@@ -7,5 +7,5 @@ license       = "MIT"
 
 # Dependencies
 
-requires "nim >= 0.18.0"
-requires "jester#v0.4.0"
+requires "nim >= 0.19.0"
+requires "jester#v0.4.1"


### PR DESCRIPTION
Hi @dom96,

`jester` was de-activated here.

This `PR` fix also #331

I also use `0.4.1` inspired by https://github.com/TechEmpower/FrameworkBenchmarks/tree/master/frameworks/Nim/jester

Regards,

