### PR TITLE
wrong kitura version displayed

### DIFF
--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -133,7 +133,7 @@ go:
 swift:
   kitura:
     website: kitura.io
-    version: "2.2"
+    version: "2.5"
   vapor:
     website: vapor.codes
     version: "3.0"


### PR DESCRIPTION
Hi,

`kitura` implementation was using `2.5.2`, but `2.2` was displayed on result table

This `PR` fix #405 

Regards,