### PR TITLE
Opcache

### DIFF
--- a/php/laravel/Dockerfile
+++ b/php/laravel/Dockerfile
@@ -2,7 +2,7 @@ FROM php:fpm
 
 RUN apt-get -qq update
 RUN apt-get -y install git nginx zlib1g-dev
-RUN docker-php-ext-install zip
+RUN docker-php-ext-install zip opcache
 
 
 WORKDIR /usr/src/app
@@ -55,6 +55,15 @@ RUN echo 'server {\n\
     }\n\
 }\n'\
 >> /etc/nginx/conf.d/www.conf
+
+RUN echo 'opcache.enable=1\n\
+opcache.memory_consumption=512\n\
+opcache.interned_strings_buffer=64\n\
+opcache.max_accelerated_files=32531\n\
+opcache.validate_timestamps=0\n\
+opcache.save_comments=1\n\
+opcache.fast_shutdown=0\n'\
+>> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 

--- a/php/slim/Dockerfile
+++ b/php/slim/Dockerfile
@@ -2,7 +2,7 @@ FROM php:fpm
 
 RUN apt-get -qq update
 RUN apt-get -y install git nginx zlib1g-dev
-RUN docker-php-ext-install zip
+RUN docker-php-ext-install zip opcache
 
 
 WORKDIR /usr/src/app
@@ -38,6 +38,15 @@ RUN echo 'server {\n\
     }\n\
 }\n'\
 >> /etc/nginx/conf.d/www.conf
+
+RUN echo 'opcache.enable=1\n\
+opcache.memory_consumption=512\n\
+opcache.interned_strings_buffer=64\n\
+opcache.max_accelerated_files=32531\n\
+opcache.validate_timestamps=0\n\
+opcache.save_comments=1\n\
+opcache.fast_shutdown=0\n'\
+>> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 

--- a/php/slim/Dockerfile
+++ b/php/slim/Dockerfile
@@ -25,16 +25,17 @@ RUN rm -fr /usr/local/etc/php-fpm.d/zz-docker.conf
 ENV APP_ENV prod
 
 RUN echo 'server {\n\
-    root /usr/src/app/public;\n\
     listen 0.0.0.0:3000;\n\
+
+    root /usr/src/app/public;\n\
+    set $front_controller /index.php;\n\
+
     location / {\n\
-        try_files $uri /index.php$is_args$args;\n\
-    }\n\
-    location ~ index\\.php {\n\
         fastcgi_pass unix:/var/run/php-fpm.sock;\n\
-        fastcgi_param   SCRIPT_FILENAME         $document_root/index.php;\n\
+
         include fastcgi_params;\n\
-        internal;\n\
+        fastcgi_param SCRIPT_FILENAME $document_root$front_controller;\n\
+        fastcgi_param SCRIPT_NAME $front_controller;\n\
     }\n\
 }\n'\
 >> /etc/nginx/conf.d/www.conf

--- a/php/slim/public/index.php
+++ b/php/slim/public/index.php
@@ -5,8 +5,7 @@ use Slim\Http;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-
-$app = new App();
+$app = new App(['settings' => ['routerCacheFile' => '/tmp']]);
 
 $app->get('/', function(Http\Request $request, Http\Response $response): Http\Response {
     return $response->write('');

--- a/php/symfony/Dockerfile
+++ b/php/symfony/Dockerfile
@@ -2,7 +2,7 @@ FROM php:fpm
 
 RUN apt-get -qq update
 RUN apt-get -y install git nginx zlib1g-dev
-RUN docker-php-ext-install zip
+RUN docker-php-ext-install zip opcache
 
 
 WORKDIR /usr/src/app
@@ -41,6 +41,15 @@ RUN echo 'server {\n\
     }\n\
 }\n'\
 >> /etc/nginx/conf.d/www.conf
+
+RUN echo 'opcache.enable=1\n\
+opcache.memory_consumption=512\n\
+opcache.interned_strings_buffer=64\n\
+opcache.max_accelerated_files=32531\n\
+opcache.validate_timestamps=0\n\
+opcache.save_comments=1\n\
+opcache.fast_shutdown=0\n'\
+>> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 


### PR DESCRIPTION
Addresses #422. The configuration in use is the one found in the article I linked in the issue. It can be validated by accessing a running laravel, slim or symfony container and typing `php-fpm -m` and `php-fpm -i | grep opca`

In addition, Slim's nginx configuration has been tweaked to avoid an unnecessary disk access per request (the `try_files` directive), and the FastRoute cache has been enabled (in the end this is what has had the biggest impact on performance ¯\\_(ツ)_/¯).