### PR TITLE
optimize amber

### DIFF
--- a/crystal/amber/Dockerfile
+++ b/crystal/amber/Dockerfile
@@ -6,8 +6,6 @@ COPY shard.yml ./
 COPY src src
 COPY config config
 
-ENV PROCESS_COUNT $(nproc)
-
 RUN shards build --release --no-debug
 
 CMD bin/server

--- a/crystal/amber/Dockerfile
+++ b/crystal/amber/Dockerfile
@@ -6,6 +6,8 @@ COPY shard.yml ./
 COPY src src
 COPY config config
 
+ENV PROCESS_COUNT $(nproc)
+
 RUN shards build --release --no-debug
 
 CMD bin/server

--- a/crystal/amber/config/application.cr
+++ b/crystal/amber/config/application.cr
@@ -75,7 +75,7 @@ Amber::Server.configure do |settings|
   # spinning an instance for each number of process specified here.
   # Rule of thumb, always leave at least 1 core available for system processes/resources.
   #
-  settings.process_count = 7
+  settings.process_count = ENV["PROCESS_COUNT"].to_i if ENV["PROCESS_COUNT"]?
   #
   #
   # PORT: This is the port that you're application will run on. Examples would be (80, 443, 3000, 8080)

--- a/crystal/amber/config/application.cr
+++ b/crystal/amber/config/application.cr
@@ -75,7 +75,7 @@ Amber::Server.configure do |settings|
   # spinning an instance for each number of process specified here.
   # Rule of thumb, always leave at least 1 core available for system processes/resources.
   #
-  settings.process_count = ENV["PROCESS_COUNT"].to_i if ENV["PROCESS_COUNT"]?
+  settings.process_count = System.cpu_count.to_i32
   #
   #
   # PORT: This is the port that you're application will run on. Examples would be (80, 443, 3000, 8080)

--- a/crystal/amber/config/application.cr
+++ b/crystal/amber/config/application.cr
@@ -21,14 +21,13 @@ require "../src/controllers/**"
 # this file, we recommend to use yaml configurations before changing any settings here.
 # Any uncommented setting here will override the YAML with the value set here.
 
-
 Amber::Server.configure do |settings|
   # Use your environment variables settings here.
   #
   # Name: A name that identifies this application. This is not internally
   # used by the framework.
   #
-  # settings.name = "Amber web application."
+  settings.name = "Amber"
   #
   #
   # Colorize Logging: specifies whether or not to use ANSI color codes
@@ -59,7 +58,7 @@ Amber::Server.configure do |settings|
   # deploying Amber to a PAAS and likely the assigned server IP is either
   # known or unknown. Defaults to an environment variable HOST
   #
-  # settings.host = ENV["HOST"] if ENV["HOST"]?
+  settings.host = "0.0.0.0"
   #
   #
   # Port Reuse: Amber supports clustering mode which allows to spin
@@ -69,14 +68,14 @@ Amber::Server.configure do |settings|
   #
   # > Read more about Linux PORT REUSE https://lwn.net/Articles/542629/
   #
-  # settings.port_reuse = true
+  settings.port_reuse = true
   #
   #
   # Process Count: This will enable Amber to be used in cluster mode,
   # spinning an instance for each number of process specified here.
   # Rule of thumb, always leave at least 1 core available for system processes/resources.
   #
-  # settings.process_count = ENV["PROCESS_COUNT"].to_i if ENV["PROCESS_COUNT"]?
+  settings.process_count = 7
   #
   #
   # PORT: This is the port that you're application will run on. Examples would be (80, 443, 3000, 8080)
@@ -126,7 +125,7 @@ Amber::Server.configure do |settings|
   # Logger: is the logger that Amber and other capable shards in the project will use
   # instead of writing directly to STDOUT. Supply a custom logger to write to syslog, etc.
   #
-  # settings.logger = Amber::Environment::Logger.new(File.open("amber.log", "w"))
+  settings.logger = Amber::Environment::Logger.new(nil)
   #
   #
 end

--- a/crystal/amber/config/routes.cr
+++ b/crystal/amber/config/routes.cr
@@ -1,4 +1,7 @@
 Amber::Server.configure do |app|
+  pipeline :web do
+  end
+
   routes :web do
     get "/", ApplicationController, :index
     get "/user/:id", ApplicationController, :get

--- a/crystal/amber/src/amber.cr
+++ b/crystal/amber/src/amber.cr
@@ -1,7 +1,4 @@
 require "../config/*"
 
 Amber.env = "production"
-Amber::Server.configure do |app|
-  app.host = "0.0.0.0"
-end
 Amber::Server.start


### PR DESCRIPTION
This does several things to provide a better comparison:
- disable logging
- removes all unnecessary middleware
- enables port_reuse
- sets number of processes to 7 to leverage the 8 cores

This addresses issue #483 