### PR TITLE
use main repo (instead fork)

### DIFF
--- a/python/cyclone/requirements.txt
+++ b/python/cyclone/requirements.txt
@@ -1,2 +1,2 @@
 twisted==18.7.0
--e git+https://github.com/ygl-rg/cyclone3.git#egg=cyclone
+-e git+https://github.com/fiorix/cyclone.git#egg=cyclone


### PR DESCRIPTION
Hi,

Thanks @fiorix for merging my patch.

I've switch from https://github.com/ygl-rg/cyclone3 to https://github.com/fiorix/cyclone

I have following error for https://github.com/the-benchmarker/web-frameworks/blob/master/python/cyclone/server.py

~~~python
2018-10-29 10:57:17+0100 Unhandled Error
        Traceback (most recent call last):
          File "/usr/lib64/python3.6/site-packages/twisted/python/log.py", line 103, in callWithLogger
            return callWithContext({"system": lp}, func, *args, **kw)
          File "/usr/lib64/python3.6/site-packages/twisted/python/log.py", line 86, in callWithContext
            return context.call({ILogContext: newCtx}, func, *args, **kw)
          File "/usr/lib64/python3.6/site-packages/twisted/python/context.py", line 122, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/usr/lib64/python3.6/site-packages/twisted/python/context.py", line 85, in callWithContext
            return func(*args,**kw)
        --- <exception caught here> ---
          File "/usr/lib64/python3.6/site-packages/twisted/internet/posixbase.py", line 614, in _doReadOrWrite
            why = selectable.doRead()
          File "/usr/lib64/python3.6/site-packages/twisted/internet/tcp.py", line 243, in doRead
            return self._dataReceived(data)
          File "/usr/lib64/python3.6/site-packages/twisted/internet/tcp.py", line 249, in _dataReceived
            rval = self.protocol.dataReceived(data)
          File "/usr/lib64/python3.6/site-packages/twisted/protocols/basic.py", line 559, in dataReceived
            self.delimiter, 1)
        builtins.TypeError: a bytes-like object is required, not 'str'
~~~

Regards,