### PR TITLE
Add Gotham benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ env:
     - FRAMEWORK=muxie
     - FRAMEWORK=nickel
     - FRAMEWORK=actix-web
+    - FRAMEWORK=gotham
     - FRAMEWORK=rocket
     - FRAMEWORK=iron
     - FRAMEWORK=restify

--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -205,6 +205,10 @@ rust:
     website: actix.rs
     version: "0.7"
     language: "1.30"
+  gotham:
+    website: gotham.rs
+    version: "0.3"
+    language: "1.30"
   iron:
     website: ironframework.io
     version: "0.6"

--- a/neph.yaml
+++ b/neph.yaml
@@ -73,6 +73,7 @@ swift:
 rust:
   depends_on:
     - actix-web
+    - gotham
     - iron
     - rocket
     - nickel
@@ -305,6 +306,11 @@ actix-web:
   commands:
     - docker build -t actix-web .
   dir: rust/actix-web
+
+gotham:
+  commands:
+    - docker build -t gotham .
+  dir: rust/gotham
 
 iron:
   commands:

--- a/rust/gotham/Cargo.toml
+++ b/rust/gotham/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "server"
+version = "0.1.0"
+authors = ["Isaac Whitfield <iw@whitfin.io>"]
+
+[dependencies]
+gotham = "0.3"
+gotham_derive = "0.3"
+hyper = "0.12"
+serde = "1.0"
+serde_derive = "1.0"
+
+[profile.release]
+codegen-units = 1
+opt-level = 3
+lto = true

--- a/rust/gotham/Dockerfile
+++ b/rust/gotham/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:1.30
+
+WORKDIR /usr/src/app
+
+COPY Cargo.toml ./
+COPY src src
+
+RUN RUSTFLAGS="-C target-cpu=native" cargo build --release
+
+EXPOSE 3000
+
+CMD target/release/server

--- a/rust/gotham/src/main.rs
+++ b/rust/gotham/src/main.rs
@@ -1,0 +1,40 @@
+extern crate gotham;
+#[macro_use]
+extern crate gotham_derive;
+extern crate hyper;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+
+use gotham::helpers::http::response;
+use gotham::router::builder::*;
+use gotham::state::*;
+use hyper::{Body, Response, StatusCode};
+
+fn main() {
+    let addr = "0.0.0.0:3000";
+    println!("Listening for requests at http://{}", addr);
+
+    let router = build_simple_router(|route| {
+        route.get("/").to(say_ok);
+        route.post("/user").to(say_ok);
+        route.get("/user/:id").to(log_user);
+    });
+
+    gotham::start(addr, router)
+}
+
+fn say_ok(state: State) -> (State, Response<Body>) {
+    let res = response::create_empty_response(&state, StatusCode::OK);
+    (state, res)
+}
+
+#[derive(Deserialize, StateData, StaticResponseExtender)]
+struct PathExtractor {
+    id: String,
+}
+
+fn log_user(mut state: State) -> (State, String) {
+    let id = PathExtractor::take_from(&mut state).id;
+    (state, id)
+}

--- a/rust/gotham/src/main.rs
+++ b/rust/gotham/src/main.rs
@@ -18,7 +18,10 @@ fn main() {
     let router = build_simple_router(|route| {
         route.get("/").to(say_ok);
         route.post("/user").to(say_ok);
-        route.get("/user/:id").to(log_user);
+        route
+            .get("/user/:id")
+            .with_path_extractor::<PathExtractor>()
+            .to(log_user);
     });
 
     gotham::start(addr, router)

--- a/rust/iron/Cargo.toml
+++ b/rust/iron/Cargo.toml
@@ -6,3 +6,8 @@ authors = ["taicsuzu <taicsuzu@yahoo-corp.jp>"]
 [dependencies]
 iron = "0.6.0"
 router = "0.6.0"
+
+[profile.release]
+codegen-units = 1
+opt-level = 3
+lto = true

--- a/rust/iron/Dockerfile
+++ b/rust/iron/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 COPY Cargo.toml ./
 COPY src src
 
-RUN cargo build --release
+RUN RUSTFLAGS="-C target-cpu=native" cargo build --release
 
 EXPOSE 3000
 

--- a/rust/nickel/Cargo.toml
+++ b/rust/nickel/Cargo.toml
@@ -5,3 +5,8 @@ authors = ["taicsuzu <taicsuzu@yahoo-corp.jp>"]
 
 [dependencies]
 nickel = "0.10.1"
+
+[profile.release]
+codegen-units = 1
+opt-level = 3
+lto = true

--- a/rust/nickel/Dockerfile
+++ b/rust/nickel/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 COPY Cargo.toml ./
 COPY src src
 
-RUN cargo build --release
+RUN RUSTFLAGS="-C target-cpu=native" cargo build --release
 
 EXPOSE 3000
 

--- a/rust/rocket/Cargo.toml
+++ b/rust/rocket/Cargo.toml
@@ -6,3 +6,8 @@ authors = ["Kilian Koeltzsch <me@kilian.io>"]
 [dependencies]
 rocket = "0.3.9"
 rocket_codegen = "0.3.9"
+
+[profile.release]
+codegen-units = 1
+opt-level = 3
+lto = true

--- a/rust/rocket/Dockerfile
+++ b/rust/rocket/Dockerfile
@@ -9,7 +9,7 @@ COPY src src
 
 ENV ROCKET_ENV=production
 
-RUN cargo build --release
+RUN RUSTFLAGS="-C target-cpu=native" cargo build --release
 
 EXPOSE 3000
 


### PR DESCRIPTION
Before submitting your PR, please review the following checklist :

## If you are adding a framework

+ [x] Please check configuration files
   + [x] `neph.yml`, for [neph](http://tbrand.github.io/neph) job processing
   + [x] `FRAMEWORKS.yml`, for **frameworks** list
   + [x] `travis.yml`, for CI
+ [x] A `Dockerfile` exists ?
+ [x] All tests passes ?
~~~
export FRAMEWORK=gotham
shards install
shards build --release
bin/neph ${FRAMEWORK}
crystal spec
~~~

## Notes

This adds tests for Gotham, and makes sure all Rust images are aligned on the same build process (since Actix was previously using compiler optimizations that the other frameworks weren't). I can't get the tests to pass locally, but I think it's due to the state of my Docker (which I can't change, because I need it for something else). If someone could validate, I'd appreciate it.