### PR TITLE
update iris from 10 to 11

### DIFF
--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -165,7 +165,7 @@ go:
     language: "1.11"
   iris:
     website: iris-go.com
-    version: "10.7"
+    version: "11.0"
     language: "1.11"
   muxie:
     website: godoc.org/github.com/kataras/muxie

--- a/go/iris/Dockerfile
+++ b/go/iris/Dockerfile
@@ -1,12 +1,10 @@
 FROM golang:1.11.1
 
 WORKDIR /go/src/app
-COPY main.go ./
+COPY main.go go.mod ./
 
-RUN go get -u github.com/kardianos/govendor
-RUN govendor init
-RUN govendor fetch github.com/kataras/iris@v10.7.0
-RUN go build main.go
+ENV GO111MODULE=on
+RUN go build .
 
 EXPOSE 3000
 CMD [ "./main" ]

--- a/go/iris/go.mod
+++ b/go/iris/go.mod
@@ -1,0 +1,3 @@
+module main
+
+require github.com/kataras/iris v11.0.2+incompatible

--- a/go/iris/main.go
+++ b/go/iris/main.go
@@ -1,22 +1,19 @@
 package main
 
-import (
-	"github.com/kataras/iris"
-	"github.com/kataras/iris/context"
-)
+import "github.com/kataras/iris"
 
 func main() {
 	app := iris.New()
 
-	app.Get("/", func(ctx context.Context) {
+	app.Get("/", func(ctx iris.Context) {
 		ctx.WriteString("")
 	})
 
-	app.Get("/user/{id}", func(ctx context.Context) {
+	app.Get("/user/{id}", func(ctx iris.Context) {
 		ctx.WriteString(ctx.Params().Get("id"))
 	})
 
-	app.Post("/user", func(ctx context.Context) {
+	app.Post("/user", func(ctx iris.Context) {
 		ctx.WriteString("")
 	})
 


### PR DESCRIPTION
Hi @kataras,

Thanks for sharing me the `+incompatible` hack in **go modules**, I honestly don't know what it does (not `golang` dev)

I have update the `iris`, fixing #503 

Regards,