### PR TITLE
be more strict on python versionning

### DIFF
--- a/crystal/kemal/src/server.cr
+++ b/crystal/kemal/src/server.cr
@@ -18,4 +18,7 @@ post "/user" do |env|
 end
 
 Kemal.config.env = "production"
-Kemal.run
+Kemal.run do |config|
+  server = config.server.not_nil!
+  server.bind_tcp "0.0.0.0", 3000, reuse_port: true
+end

--- a/python/aiohttp/requirements.txt
+++ b/python/aiohttp/requirements.txt
@@ -1,3 +1,3 @@
-aiohttp==3.4.*
-gunicorn==19.9.*
-uvloop==0.11.*
+aiohttp==3.4.4
+gunicorn==19.9.0
+uvloop==0.11.3

--- a/python/bottle/requirements.txt
+++ b/python/bottle/requirements.txt
@@ -1,3 +1,3 @@
-bottle==0.12.*
-gunicorn==19.9.*
-meinheld==0.6.*
+bottle==0.12.13
+gunicorn==19.9.0
+meinheld==0.6.1

--- a/python/cyclone/requirements.txt
+++ b/python/cyclone/requirements.txt
@@ -1,2 +1,2 @@
-twisted==18.7.0
+twisted==18.9.0
 -e git+https://github.com/ygl-rg/cyclone3.git#egg=cyclone

--- a/python/django/requirements.txt
+++ b/python/django/requirements.txt
@@ -1,3 +1,3 @@
-django>=2.1.2,<3.0.0
-gunicorn==19.9.*
-meinheld==0.6.*
+django==2.1.3
+gunicorn==19.9.0
+meinheld==0.6.1

--- a/python/falcon/requirements.txt
+++ b/python/falcon/requirements.txt
@@ -1,3 +1,3 @@
-falcon==1.4.*
-gunicorn==19.9.*
-meinheld==0.6.*
+falcon==1.4.1
+gunicorn==19.9.0
+meinheld==0.6.1

--- a/python/flask/requirements.txt
+++ b/python/flask/requirements.txt
@@ -1,3 +1,3 @@
-Flask==1.0.*
-gunicorn==19.9.*
-meinheld==0.6.*
+Flask==1.0.2
+gunicorn==19.9.0
+meinheld==0.6.1

--- a/python/japronto/requirements.txt
+++ b/python/japronto/requirements.txt
@@ -1,1 +1,2 @@
 japronto==0.1.1
+uvloop==0.8.1

--- a/python/japronto/requirements.txt
+++ b/python/japronto/requirements.txt
@@ -1,2 +1,1 @@
-japronto==0.1.*
-uvloop==0.8.1
+japronto==0.1.1

--- a/python/quart/requirements.txt
+++ b/python/quart/requirements.txt
@@ -1,3 +1,3 @@
-quart==0.6.*
-gunicorn==19.9.*
-uvicorn==0.3.*
+quart==0.6.8
+gunicorn==19.9.0
+uvicorn==0.3.17

--- a/python/responder/Dockerfile
+++ b/python/responder/Dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:3.6
 
 WORKDIR /usr/src/app
 

--- a/python/sanic/requirements.txt
+++ b/python/sanic/requirements.txt
@@ -1,2 +1,2 @@
-sanic==0.8.*
-gunicorn==19.9.*
+sanic==0.8.3
+gunicorn==19.9.0

--- a/python/starlette/requirements.txt
+++ b/python/starlette/requirements.txt
@@ -1,3 +1,3 @@
-starlette==0.6.3
+starlette==0.7.0
 gunicorn==19.9.0
 uvicorn==0.3.17

--- a/python/tornado/requirements.txt
+++ b/python/tornado/requirements.txt
@@ -1,1 +1,1 @@
-tornado==5.1.*
+tornado==5.1.1


### PR DESCRIPTION
Hi,

This `PR` specify strict versions of each dependencies for `python` **based** _frameworks_

This **COULD** be done because of http://pyup.io and it **COULD** avoid some side-effects
https://pyup.io/account/repos/github/the-benchmarker/web-frameworks/

Regards,