### PR TITLE
Upgrade node

### DIFF
--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -39,7 +39,7 @@ node:
   foxify:
     website: foxify.js.org
     version: "0.10"
-    language: "10.12"
+    language: "11.1"
   polka:
     github: lukeed/polka
     version: "0.5"

--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -35,7 +35,7 @@ node:
   fastify:
     website: fastify.io
     version: "1.13"
-    language: "10.12"
+    language: "11.1"
   foxify:
     website: foxify.js.org
     version: "0.10"

--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -31,7 +31,7 @@ node:
   express:
     website: expressjs.com
     version: "4.16"
-    language: "10.12"
+    language: "11.1"
   fastify:
     website: fastify.io
     version: "1.13"

--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -47,7 +47,7 @@ node:
   rayo:
     website: rayo.js.org
     version: "1.2"
-    language: "10.12"
+    language: "11.1"
   koa:
     website: koajs.com
     version: "2.6"

--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -64,7 +64,7 @@ node:
     github: mafintosh/turbo-http
     version: "0.3"
     type: experimental
-    language: "10.12"
+    language: "11.1"
 python:
   sanic:
     github: huge-success/sanic

--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -59,7 +59,7 @@ node:
   hapi:
     website: hapijs.com
     version: "17.6"
-    language: "10.12"
+    language: "11.1"
   turbo_polka:
     github: mafintosh/turbo-http
     version: "0.3"

--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -43,7 +43,7 @@ node:
   polka:
     github: lukeed/polka
     version: "0.5"
-    language: "10.12"
+    language: "11.1"
   rayo:
     website: rayo.js.org
     version: "1.2"

--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -55,7 +55,7 @@ node:
   restify:
     website: restify.com
     version: "7.2"
-    language: "10.12"
+    language: "11.1"
   hapi:
     website: hapijs.com
     version: "17.6"

--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -51,7 +51,7 @@ node:
   koa:
     website: koajs.com
     version: "2.6"
-    language: "10.12"
+    language: "11.1"
   restify:
     website: restify.com
     version: "7.2"

--- a/node/express/Dockerfile
+++ b/node/express/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.12
+FROM node:11.1
 
 RUN npm -g install pm2
 

--- a/node/fastify/Dockerfile
+++ b/node/fastify/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.12
+FROM node:11.1
 
 RUN npm -g install pm2
 

--- a/node/foxify/Dockerfile
+++ b/node/foxify/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.12
+FROM node:11.1
 
 RUN npm -g install pm2
 

--- a/node/hapi/Dockerfile
+++ b/node/hapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.12
+FROM node:11.1
 
 RUN npm -g install pm2
 

--- a/node/koa/Dockerfile
+++ b/node/koa/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.12
+FROM node:11.1
 
 RUN npm -g install pm2
 

--- a/node/polka/Dockerfile
+++ b/node/polka/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.12
+FROM node:11.1
 
 RUN npm -g install pm2
 

--- a/node/rayo/Dockerfile
+++ b/node/rayo/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.12
+FROM node:11.1
 
 RUN npm -g install pm2
 

--- a/node/restify/Dockerfile
+++ b/node/restify/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.12
+FROM node:11.1
 
 RUN npm -g install pm2
 

--- a/node/turbo_polka/Dockerfile
+++ b/node/turbo_polka/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.12
+FROM node:11.1
 
 RUN npm -g install pm2
 


### PR DESCRIPTION
Hi,

`node` **11**  is out, https://medium.com/@nodejs/october-brings-node-js-10-x-to-lts-and-node-js-11-to-current-ae19f8f12b51

This `PR` turn all `nodejs` based **frameworks** using latest `nodejs` release :

+ [x] express
+ [x] fastify
+ [x] foxify
+ [x] hapi
+ [x] koa  
+ [x] polka
+ [x] rayo
+ [x] restify
+ [x] turbo_polka

Regards,