### PR TITLE
Fix responder (temporary fix)

### DIFF
--- a/python/responder/requirements.txt
+++ b/python/responder/requirements.txt
@@ -1,3 +1,3 @@
 -e git+https://github.com/kennethreitz/responder.git#egg=responder
-gunicorn==19.9.*
+gunicorn==19.9.0
 uvicorn==0.3.20

--- a/python/responder/requirements.txt
+++ b/python/responder/requirements.txt
@@ -1,3 +1,3 @@
-responder==1.1.*
+-e git+https://github.com/kennethreitz/responder.git#egg=responder
 gunicorn==19.9.*
 uvicorn==0.3.20


### PR DESCRIPTION
Hi @kennethreitz,

I can see that line 16 of `api.py` importing **debug** module of **starlette** was failing my tests
https://github.com/kennethreitz/responder/blob/v1.1.1/responder/api.py#L16

I can see that this line in not present anymore in **master**

I've the switch to **master** (even if this is temporary), do have a working `CI`

I'll revert this until `responder` will be pushed on pypy

Regards,