### PR TITLE
fix node version in display

### DIFF
--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -35,11 +35,11 @@ node:
   fastify:
     website: fastify.io
     version: "1.13"
-    language: "10.12"
+    language: "11.1"
   foxify:
     website: foxify.js.org
     version: "0.10"
-    language: "10.12"
+    language: "11.1"
   polka:
     github: lukeed/polka
     version: "0.5"


### PR DESCRIPTION
Hi,

For `fastify` and `foxify` version of `node` in **results** was not the one in use

Regards,