### PR TITLE
use python 3.7 on japronto

### DIFF
--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -108,7 +108,7 @@ python:
     type: experimental
     language: "3.7"
   japronto:
-    language: "3.6"
+    language: "3.7"
     version: "0.1"
     github: squeaky-pl/japronto
   falcon:

--- a/go/fasthttprouter/go.mod
+++ b/go/fasthttprouter/go.mod
@@ -1,6 +1,3 @@
 module main
 
-require (
-	github.com/buaazp/fasthttprouter v0.1.1
-	github.com/valyala/fasthttp v0.0.0-20171207120941-e5f51c11919d
-)
+require github.com/buaazp/fasthttprouter v0.1.1

--- a/python/japronto/Dockerfile
+++ b/python/japronto/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7.1
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Hi,

Since `uvloop` support `python` **3.7** (https://github.com/MagicStack/uvloop/releases/tag/v0.10.0), we can use this version for `japronto`

<hr>

Before submitting your PR, please review the following checklist :

## If you are adding a framework

+ [x] Please check configuration files
   + [x] `neph.yml`, for [neph](http://tbrand.github.io/neph) job processing
   + [x] `FRAMEWORKS.yml`, for **frameworks** list
   + [x] `travis.yml`, for CI
+ [x] A `Dockerfile` exists ?
+ [x] All tests passes ?
~~~
export FRAMEWORK=japronto
shards install
shards build --release
bin/neph ${FRAMEWORK}
crystal spec
~~~
