### PR TITLE
Use gunicorn with tornado

### DIFF
--- a/python/tornado/Dockerfile
+++ b/python/tornado/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 3000
 
-CMD python server.py
+CMD gunicorn --log-level warning --bind 0.0.0.0:3000 --reuse-port --workers $(nproc) --worker-class gunicorn.workers.gtornado.TornadoWorker server:app

--- a/python/tornado/requirements.txt
+++ b/python/tornado/requirements.txt
@@ -1,1 +1,2 @@
 tornado==5.1.1
+gunicorn==19.9.0

--- a/python/tornado/server.py
+++ b/python/tornado/server.py
@@ -20,11 +20,6 @@ class UserInfoHandler(tornado.web.RequestHandler):
         self.write(id)
 
 
-if __name__ == '__main__':
-    app = tornado.web.Application(handlers=[(r'/', MainHandler),
-                                  (r"/user", UserHandler),
-                                  (r"/user/(\d+)", UserInfoHandler)])
-    http_server = tornado.httpserver.HTTPServer(app)
-    http_server.bind(3000, address='0.0.0.0', reuse_port=True)
-    http_server.start(0)
-    tornado.ioloop.IOLoop.current().start()
+app = tornado.web.Application(handlers=[(r'/', MainHandler),
+                              (r"/user", UserHandler),
+                              (r"/user/(\d+)", UserInfoHandler)])


### PR DESCRIPTION
Hi,

This `PR` aims to use `gunicorn` on top of `tornado` (instead of it own implementation)

The purpose is to make uniform all implementations (use `gunicorn` in the maximu of `python` **implementations**)

Addresses #720 

Regards,