### PR TITLE
disable renovate for golang

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,8 @@
   ],
   "python": {
     "enabled": false
+  },
+  "golang": {
+    "enabled": false
   }
 }


### PR DESCRIPTION
Hi,

This `PR` disable `golang` on **renovate**

`renovate` remove `+incompatible` flag, @dependabot will replace it, thus

Addresses #764 

Regards,