### PR TITLE
upgrade chi to 4.0

### DIFF
--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -229,7 +229,7 @@ go:
     language: "1.11"
   chi:
     github: go-chi/chi
-    version: "3.3"
+    version: "4.0"
     language: "1.11"
 swift:
   kitura:

--- a/go/chi/go.mod
+++ b/go/chi/go.mod
@@ -1,3 +1,3 @@
 module main
 
-require github.com/go-chi/chi v3.3.4+incompatible
+require github.com/go-chi/chi v4.0.1+incompatible


### PR DESCRIPTION
Hi,

This `PR` upgrade `chi` to the next major

Major version are not updated by @dependabot on `golang`

Regards,