### PR TITLE
Use all computing units available

### DIFF
--- a/crystal/raze/src/server.cr
+++ b/crystal/raze/src/server.cr
@@ -15,4 +15,5 @@ end
 Raze.config.logging = false
 Raze.config.port = 3000
 Raze.config.env = "production"
+Raze.config.reuse_port = true
 Raze.run

--- a/php/laravel/Dockerfile
+++ b/php/laravel/Dockerfile
@@ -45,7 +45,7 @@ RUN rm -fr /usr/local/etc/php-fpm.d/zz-docker.conf
 
 RUN echo 'server {\n\
     root /usr/src/app/public;\n\
-    listen 0.0.0.0:3000;\n\
+    listen 0.0.0.0:3000 reuseport;\n\
     index index.php;\n\
 \n\
     add_header X-Frame-Options "SAMEORIGIN";\n\

--- a/php/lumen/Dockerfile
+++ b/php/lumen/Dockerfile
@@ -44,7 +44,7 @@ RUN rm -fr /usr/local/etc/php-fpm.d/zz-docker.conf
 
 RUN echo 'server {\n\
     root /usr/src/app/public;\n\
-    listen 0.0.0.0:3000;\n\
+    listen 0.0.0.0:3000 reuseport;\n\
     index index.php;\n\
 \n\
     add_header X-Frame-Options "SAMEORIGIN";\n\

--- a/php/slim/Dockerfile
+++ b/php/slim/Dockerfile
@@ -27,7 +27,7 @@ RUN rm -fr /usr/local/etc/php-fpm.d/zz-docker.conf
 ENV APP_ENV prod
 
 RUN echo 'server {\n\
-    listen 0.0.0.0:3000;\n\
+    listen 0.0.0.0:3000 reuseport;\n\
 
     root /usr/src/app/public;\n\
     set $front_controller /index.php;\n\

--- a/php/symfony/Dockerfile
+++ b/php/symfony/Dockerfile
@@ -33,7 +33,7 @@ RUN php bin/console cache:warmup
 
 RUN echo 'server {\n\
     root /usr/src/app/public;\n\
-    listen 0.0.0.0:3000;\n\
+    listen 0.0.0.0:3000 reuseport;\n\
     location / {\n\
         fastcgi_pass unix:/var/run/php-fpm.sock;\n\
         fastcgi_param   SCRIPT_FILENAME         $document_root/index.php;\n\

--- a/php/zend-expressive/Dockerfile
+++ b/php/zend-expressive/Dockerfile
@@ -29,7 +29,7 @@ RUN rm -fr /usr/local/etc/php-fpm.d/zz-docker.conf
 ENV APP_ENV prod
 
 RUN echo 'server {\n\
-    listen 0.0.0.0:3000;\n\
+    listen 0.0.0.0:3000 reuseport;\n\
     root /usr/src/app/public;\n\
     set $front_controller /index.php;\n\
     location / {\n\

--- a/php/zend-framework/Dockerfile
+++ b/php/zend-framework/Dockerfile
@@ -29,7 +29,7 @@ RUN rm -fr /usr/local/etc/php-fpm.d/zz-docker.conf
 ENV APP_ENV prod
 
 RUN echo 'server {\n\
-    listen 0.0.0.0:3000;\n\
+    listen 0.0.0.0:3000 reuseport;\n\
     root /usr/src/app/public;\n\
     set $front_controller /index.php;\n\
     location / {\n\


### PR DESCRIPTION
Hi,

This `PR` aims to implements (or check) whole CPU usage, it closes #69

This feature **COULD** be :
+ `SO_REUSEPORT` via `spawn`/`fork`
+ a custom implementation
+ ...

+ [x] nim
   + [x] jester
+ [x] elixir
   + [x] plug
   + [x] phoenix
+ [x] go
   + [x] fasthttprouter
   + [x] violetear
   + [x] kami
   + [x] gorilla-mux
   + [x] gin
   + [x] chi
   + [x] beego
   + [x] gf
   + [x] echo
+ [ ] kotlin
   + [ ] ktor
+ [ ] swift
   + [ ] kitura
   + [ ] perfect
   + [ ] vapor
+ [x] php
  + [x] symfony
  + [x] zend-framework
  + [x] laravel
  + [x] lumen
  + [x] zend-expressive
  + [x] slim
+ [ ] scala
   + [x] akkahttp
   + [x] http4s
+ [ x] rust
   + [ ] iron
   + [x] gotham
   + [ ] rocket
   + [ ] actix-web
   + [ ] nickel
+ [ ] objc
   + [ ] criollo
+ [x] python
   + [x] aiohttp
   + [x] tornado
   + [x] flask
   + [x] django
   + [x] vibora
   + [x] molten
   + [x] hug
   + [x] fastapi
   + [x] quart
   + [x] responder
   + [x] cyclone
   + [x] bocadillo
   + [x] sanic
   + [x] bottle
   + [x] falcon
   + [x] japronto
   + [x] starlette
+ [] crystal
   + [x] onyx
   + [x] orion
   + [ ] athena
   + [x] kemal
   + [x] router.cr
   + [x] spider-gazelle
   + [x] lucky
   + [x] amber
+ [ ] csharp
   + [ ] aspnetcore
+ [x] node
   + [x] polka
   + [x] restana
   + [x] turbo_polka
   + [x] restify
   + [x] foxify
   + [x] express
   + [x] koa
   + [x] rayo
   + [x] muneem
   + [x] fastify
   + [x] hapi
+ [x] java
   + [x] act
+ [x] cpp
   + [x] evhtp
+ [x] ruby
   + [x] hanami
   + [x] rails
   + [x] flame
   + [x] agoo
   + [x] roda
   + [x] sinatra
   + [x] rack-routing
   + [x] cuba
+ [ ] c
  + [x] agoo-c
  + [ ] kore


Regards,
