### PR TITLE
Upgrade echo to 4x

### DIFF
--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -197,7 +197,7 @@ go:
     language: "1.11"
   echo:
     website: echo.labstack.com
-    version: "3.3"
+    version: "4.0"
     language: "1.11"
   iris:
     website: iris-go.com

--- a/go/echo/go.mod
+++ b/go/echo/go.mod
@@ -1,3 +1,3 @@
 module main
 
-require github.com/labstack/echo v3.3.10+incompatible
+require github.com/labstack/echo v4.0.0

--- a/go/echo/go.mod
+++ b/go/echo/go.mod
@@ -1,3 +1,3 @@
 module main
 
-require github.com/labstack/echo v4.0.0
+require github.com/labstack/echo/v4 v4.0.0

--- a/go/echo/main.go
+++ b/go/echo/main.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/labstack/echo"
 	"net/http"
+
+	"github.com/labstack/echo/v4"
 )
 
 func main() {


### PR DESCRIPTION
Hi @alexaandru,

How can I use `echo` **4.0.0** using go modules ?

There is my `go.mod` file 
https://github.com/waghanza/http-benchmark/blob/upgrade_echo/go/echo/go.mod

Addresses #920

Regards,


