### PR TITLE
Intoduce kami

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -249,6 +249,15 @@ update_configs:
   - package_manager: "go:modules"
     directory: "/go/gorilla-mux"
     update_schedule: "daily"
+
+  - package_manager: "go:modules"
+    directory: "/go/kami"
+    update_schedule: "daily"
+    default_reviewers:
+      - guregu
+    default_labels:
+      - language:go
+
     
   # Dockefiles
   # This create PR for development environment

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,4 +1,5 @@
 version: 1
+
 update_configs:
 
     #############################
@@ -8,30 +9,44 @@ update_configs:
   - package_manager: "ruby:bundler"
     update_schedule: "live"
     directory: "/ruby/sinatra"
+    default_labels:
+      - language:ruby
 
   - package_manager: "ruby:bundler"
     update_schedule: "live"
     directory: "/ruby/rack-routing"
+    default_labels:
+      - language:ruby
 
   - package_manager: "ruby:bundler"
     update_schedule: "live"
     directory: "/ruby/hanami"
+    default_labels:
+      - language:ruby
     
   - package_manager: "ruby:bundler"
     update_schedule: "live"
     directory: "/ruby/agoo"
+    default_labels:
+      - language:ruby
 
   - package_manager: "ruby:bundler"
     update_schedule: "live"
     directory: "/ruby/roda"
+    default_labels:
+      - language:ruby
     
   - package_manager: "ruby:bundler"
     update_schedule: "live"
     directory: "/ruby/flame"
+    default_labels:
+      - language:ruby
 
   - package_manager: "ruby:bundler"
     update_schedule: "live"
     directory: "/ruby/rails"
+    default_labels:
+      - language:ruby
     
     #########################
     #### RUST FRAMEWORKS ####
@@ -40,22 +55,32 @@ update_configs:
   - package_manager: "rust:cargo"
     update_schedule: "live"
     directory: "/rust/nickel"
+    default_labels:
+      - language:rust
     
   - package_manager: "rust:cargo"
     update_schedule: "live"
     directory: "/rust/iron"
+    default_labels:
+      - language:rust
     
   - package_manager: "rust:cargo"
     update_schedule: "live"
     directory: "/rust/rocket"
+    default_labels:
+      - language:rust
     
   - package_manager: "rust:cargo"
     update_schedule: "live"
     directory: "/rust/actix-web"
+    default_labels:
+      - language:rust
     
   - package_manager: "rust:cargo"
     update_schedule: "live"
     directory: "/rust/gotham"
+    default_labels:
+      - language:rust
     
     ###########################
     #### PYTHON FRAMEWORKS ####
@@ -64,70 +89,104 @@ update_configs:
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/japronto"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/flask"
+    default_labels:
+      - language:python
     
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/falcon"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/responder"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/cyclone"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/starlette"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/hug"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/django"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/sanic"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/bottle"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/bocadillo"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/fastapi"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/tornado"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/molten"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/aiohttp"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/vibora"
+    default_labels:
+      - language:python
 
   - package_manager: "python"
     update_schedule: "live"
     directory: "/python/quart"
+    default_labels:
+      - language:python
   
     ############################
     ###### PHP FRAMEWORKS ######
@@ -136,26 +195,38 @@ update_configs:
   - package_manager: "php:composer"
     update_schedule: "live"
     directory: "/php/zend-framework"
+    default_labels:
+      - language:php
 
   - package_manager: "php:composer"
     update_schedule: "live"
     directory: "/php/zend-expressive"
+    default_labels:
+      - language:php
 
   - package_manager: "php:composer"
     update_schedule: "live"
     directory: "/php/slim"
+    default_labels:
+      - language:php
 
   - package_manager: "php:composer"
     update_schedule: "live"
     directory: "/php/symfony"
+    default_labels:
+      - language:php
 
   - package_manager: "php:composer"
     update_schedule: "live"
     directory: "/php/laravel"
+    default_labels:
+      - language:php
 
   - package_manager: "php:composer"
     update_schedule: "live"
     directory: "/php/lumen"
+    default_labels:
+      - language:php
 
     #############################
     ######### JAVASCRIPT ########
@@ -165,42 +236,62 @@ update_configs:
   - package_manager: "javascript"
     update_schedule: "live"
     directory: "/node/foxify"
+    default_labels:
+      - language:javascript
 
   - package_manager: "javascript"
     update_schedule: "live"
     directory: "/node/turbo_polka"
+    default_labels:
+      - language:javascript
 
   - package_manager: "javascript"
     update_schedule: "live"
     directory: "/node/fastify"
+    default_labels:
+      - language:javascript
 
   - package_manager: "javascript"
     update_schedule: "live"
     directory: "/node/hapi"
+    default_labels:
+      - language:javascript
 
   - package_manager: "javascript"
     update_schedule: "live"
     directory: "/node/muneem"
+    default_labels:
+      - language:javascript
 
   - package_manager: "javascript"
     update_schedule: "live"
     directory: "/node/restify"
+    default_labels:
+      - language:javascript
     
   - package_manager: "javascript"
     update_schedule: "live"
     directory: "/node/polka"
+    default_labels:
+      - language:javascript
 
   - package_manager: "javascript"
     update_schedule: "live"
     directory: "/node/rayo"
+    default_labels:
+      - language:javascript
 
   - package_manager: "javascript"
     update_schedule: "live"
     directory: "/node/koa"
+    default_labels:
+      - language:javascript
 
   - package_manager: "javascript"
     update_schedule: "live"
     directory: "/node/restana"
+    default_labels:
+      - language:javascript
 
     ###############################
     ####### JAVA FRAMEWORKS #######
@@ -209,6 +300,8 @@ update_configs:
   - package_manager: "java:maven"
     directory: "/java/act"
     update_schedule: "daily"
+    default_labels:
+      - language:java
 
     ###############################
     ######## GO FRAMEWORKS ########
@@ -217,38 +310,56 @@ update_configs:
   - package_manager: "go:modules"
     directory: "/go/gin"
     update_schedule: "daily"
+    default_labels:
+      - language:go
 
   - package_manager: "go:modules"
     directory: "/go/fasthttprouter"
     update_schedule: "daily"
+    default_labels:
+      - language:go
 
   - package_manager: "go:modules"
     directory: "/go/beego"
     update_schedule: "daily"
+    default_labels:
+      - language:go
 
   - package_manager: "go:modules"
     directory: "/go/gf"
     update_schedule: "daily"
+    default_labels:
+      - language:go
 
   - package_manager: "go:modules"
     directory: "/go/echo"
     update_schedule: "daily"
+    default_labels:
+      - language:go
 
   - package_manager: "go:modules"
     directory: "/go/iris"
     update_schedule: "daily"
+    default_labels:
+      - language:go
 
   - package_manager: "go:modules"
     directory: "/go/muxie"
     update_schedule: "daily"
+    default_labels:
+      - language:go
 
   - package_manager: "go:modules"
     directory: "/go/chi"
     update_schedule: "daily"
+    default_labels:
+      - language:go
 
   - package_manager: "go:modules"
     directory: "/go/gorilla-mux"
     update_schedule: "daily"
+    default_labels:
+      - language:go
 
   - package_manager: "go:modules"
     directory: "/go/kami"
@@ -266,55 +377,83 @@ update_configs:
   - package_manager: "docker"
     update_schedule: "daily"
     directory: "/node/rayo"
+    default_labels:
+      - docker
 
   - package_manager: "docker"
     update_schedule: "daily"
     directory: "/csharp/aspnetcore"
+    default_labels:
+      - docker
     
   - package_manager: "docker"
     update_schedule: "daily"
     directory: "/elixir/phoenix"
+    default_labels:
+      - docker
     
   - package_manager: "docker"
     update_schedule: "daily"
     directory: "/scala/http4s"
+    default_labels:
+      - docker
 
   - package_manager: "docker"
     update_schedule: "daily"
     directory: "/cpp/evhtp"
+    default_labels:
+      - docker
 
   - package_manager: "docker"
     update_schedule: "daily"
     directory: "/php/laravel"
+    default_labels:
+      - docker
     
   - package_manager: "docker"
     update_schedule: "daily"
     directory: "/python/aiohttp"
+    default_labels:
+      - docker
 
   - package_manager: "docker"
     update_schedule: "daily"
     directory: "/c/kore"
+    default_labels:
+      - docker
     
   - package_manager: "docker"
     update_schedule: "daily"
     directory: "/nim/jester"
+    default_labels:
+      - docker
 
   - package_manager: "docker"
     update_schedule: "daily"
     directory: "/java/act"
+    default_labels:
+      - docker
     
   - package_manager: "docker"
     update_schedule: "daily"
     directory: "/ruby/cuba"
+    default_labels:
+      - docker
     
   - package_manager: "docker"
     update_schedule: "daily"
     directory: "/swift/vapor"
+    default_labels:
+      - docker
     
   - package_manager: "docker"
     update_schedule: "daily"
     directory: "/go/gorilla-mux"
+    default_labels:
+      - docker
 
   - package_manager: "docker"
     update_schedule: "daily"
     directory: "/rust/iron"
+    default_labels:
+      - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,7 @@ env:
     - FRAMEWORK=gf
     - FRAMEWORK=gorilla-mux
     - FRAMEWORK=chi
+    - FRAMEWORK=kami
     - FRAMEWORK=muxie
     - FRAMEWORK=nickel
     - FRAMEWORK=actix-web

--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -243,6 +243,10 @@ go:
     github: go-chi/chi
     version: "4.0"
     language: "1.11"
+  kami:
+    github: "guregu/kami"
+    version: "2.2"
+    language: "1.11"
 swift:
   kitura:
     website: kitura.io

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ bin/benchmarker [tools]
 ## Results
 
 <!-- Result from here -->
-Last update: 2019-02-26
+Last update: 2019-02-27
 ```
 OS: Linux (version: 4.16.3-301.fc28.x86_64, arch: x86_64)
 CPU Cores: 8
@@ -92,88 +92,89 @@ CPU Cores: 8
 :three: rack-routing (ruby)
 
 
-:four: iron (rust)
+:four: flame (ruby)
 
 
-:five: flame (ruby)
+:five: hanami (ruby)
 
 
 #### Full table
 
 | Language (Runtime) | Framework (Middleware) | Average | 50th percentile | 90th percentile | 99th percentile | 99.9th percentile | Standard deviation |
 |---------------------------|---------------------------|----------------:|----------------:|----------------:|----------------:|----------------:|----------------:|
-| rust (1.32) | [nickel](http://nickel-org.github.io) (0.11) | 0.08 ms | 0.08 ms | 0.11 ms | 0.14 ms | 13.08 ms | 97.00 | 
-| ruby (2.6) | [roda](http://roda.jeremyevans.net) (3.16) | 4.58 ms | 0.22 ms | 18.12 ms | 47.31 ms | 141.90 ms | 10391.00 | 
-| ruby (2.6) | [rack-routing](http://github.com/georgeu2000/rack-routing) (0.0) | 6.16 ms | 0.28 ms | 24.75 ms | 60.72 ms | 154.90 ms | 13578.00 | 
-| rust (1.32) | [iron](http://ironframework.io) (0.6) | 0.49 ms | 0.42 ms | 0.68 ms | 2.50 ms | 106.74 ms | 1141.33 | 
-| ruby (2.6) | [flame](http://github.com/AlexWayfer/flame) (4.18) | 8.28 ms | 0.44 ms | 29.58 ms | 66.66 ms | 160.19 ms | 15235.67 | 
-| ruby (2.6) | [hanami](http://hanamirb.org) (1.3) | 11.39 ms | 0.54 ms | 42.35 ms | 92.99 ms | 240.00 ms | 21582.67 | 
-| ruby (2.6) | [sinatra](http://sinatrarb.com) (2.0) | 12.71 ms | 0.68 ms | 43.83 ms | 92.92 ms | 236.62 ms | 21787.00 | 
-| php (7.3) | [laravel](http://laravel.com) (5.7) | 198.82 ms | 0.89 ms | 563.49 ms | 3252.68 ms | 7064.14 ms | 611021.67 | 
-| php (7.3) | [symfony](http://symfony.com) (4.2) | 187.91 ms | 1.04 ms | 392.47 ms | 3678.56 ms | 7280.51 ms | 647857.67 | 
-| php (7.3) | [lumen](http://lumen.laravel.com) (5.7) | 168.69 ms | 1.32 ms | 333.03 ms | 3481.56 ms | 6484.80 ms | 595673.00 | 
-| php (7.3) | [zend-framework](http://framework.zend.com) (3.1) | 118.18 ms | 1.70 ms | 294.30 ms | 2238.95 ms | 5957.97 ms | 423248.67 | 
-| php (7.3) | [zend-expressive](http://zendframework.github.io/zend-expressive) (3.2) | 194.60 ms | 1.99 ms | 435.88 ms | 3810.56 ms | 7654.98 ms | 678738.67 | 
-| rust (nightly) | [rocket](http://rocket.rs) (0.4) | 57.86 ms | 2.04 ms | 6.35 ms | 1579.31 ms | 3583.45 ms | 289141.33 | 
-| rust (1.32) | [actix-web](http://actix.rs) (0.7) | 4.16 ms | 3.34 ms | 8.44 ms | 18.33 ms | 68.09 ms | 3863.33 | 
-| c (11) | [agoo-c](http://github.com/ohler55/agoo-c) (0.3) | 5.79 ms | 3.39 ms | 13.83 ms | 29.66 ms | 149.85 ms | 6456.67 | 
-| python (3.7) | [japronto](http://github.com/squeaky-pl/japronto) (0.1) | 4.68 ms | 3.70 ms | 9.98 ms | 23.11 ms | 106.06 ms | 5041.33 | 
-| ruby (2.6) | [rails](http://rubyonrails.org) (5.2) | 51.50 ms | 4.07 ms | 171.67 ms | 480.13 ms | 1325.62 ms | 101406.33 | 
-| python (3.6) | [vibora](http://vibora.io) (0.0) | 5.78 ms | 4.42 ms | 11.76 ms | 25.13 ms | 97.15 ms | 5322.33 | 
-| php (7.3) | [slim](http://slimframework.com) (3.12) | 269.41 ms | 4.87 ms | 505.09 ms | 5160.24 ms | 7517.60 ms | 894521.33 | 
-| crystal (0.27) | [onyx](http://github.com/onyxframework/rest) (0.6) | 7.45 ms | 4.92 ms | 16.03 ms | 41.47 ms | 205.09 ms | 9768.00 | 
-| cpp (11.0) | [evhtp](http://github.com/criticalstack/libevhtp) (1.2) | 5.73 ms | 5.05 ms | 9.74 ms | 25.80 ms | 115.44 ms | 4807.00 | 
-| go (1.11) | [fasthttprouter](http://godoc.org/github.com/buaazp/fasthttprouter) (0.1) | 6.17 ms | 5.26 ms | 10.48 ms | 23.29 ms | 92.83 ms | 4402.67 | 
-| crystal (0.27) | [spider-gazelle](http://spider-gazelle.net) (1.4) | 7.96 ms | 5.33 ms | 17.27 ms | 38.91 ms | 179.76 ms | 9010.00 | 
-| rust (1.32) | [gotham](http://gotham.rs) (0.3) | 7.10 ms | 5.39 ms | 13.77 ms | 30.51 ms | 246.64 ms | 8577.00 | 
-| nim (0.19) | [jester](http://github.com/dom96/jester) (0.4) | 7.39 ms | 5.61 ms | 15.71 ms | 30.54 ms | 118.93 ms | 6420.00 | 
-| node (11.10) | [restana](http://github.com/jkyberneees/ana) (2.9) | 7.74 ms | 5.76 ms | 11.68 ms | 28.56 ms | 317.53 ms | 9760.00 | 
-| node (11.10) | [rayo](http://rayo.js.org) (1.2) | 9.44 ms | 6.54 ms | 16.39 ms | 42.87 ms | 386.36 ms | 13646.33 | 
-| node (11.10) | [polka](http://github.com/lukeed/polka) (0.5) | 9.86 ms | 6.57 ms | 18.18 ms | 49.04 ms | 383.55 ms | 13841.00 | 
-| go (1.11) | [muxie](http://godoc.org/github.com/kataras/muxie) (1.0) | 8.70 ms | 6.92 ms | 14.65 ms | 31.14 ms | 228.19 ms | 7282.33 | 
-| ruby (2.6) | [agoo](http://github.com/ohler55/agoo) (2.8) | 12.91 ms | 6.98 ms | 29.44 ms | 95.73 ms | 166.69 ms | 17946.00 | 
-| java (8) | [act](http://actframework.org) (1.8) | 8.87 ms | 7.51 ms | 15.13 ms | 35.55 ms | 171.99 ms | 7742.67 | 
-| c (99) | [kore](http://kore.io) (3.1) | 8.95 ms | 7.56 ms | 16.11 ms | 37.49 ms | 181.91 ms | 7335.00 | 
-| go (1.11) | [chi](http://github.com/go-chi/chi) (4.0) | 9.47 ms | 7.73 ms | 16.19 ms | 32.45 ms | 240.12 ms | 7523.00 | 
-| scala (2.12) | [akkahttp](http://akka.io) (10.1) | 165.65 ms | 7.80 ms | 25.85 ms | 4596.86 ms | 7919.60 ms | 759082.00 | 
-| csharp (7.3) | [aspnetcore](http://docs.microsoft.com/en-us/aspnet/index) (2.2) | 9.95 ms | 8.04 ms | 16.78 ms | 43.23 ms | 227.67 ms | 9087.67 | 
-| node (11.10) | [foxify](http://foxify.js.org) (0.10) | 11.57 ms | 9.03 ms | 20.01 ms | 51.48 ms | 424.53 ms | 16267.33 | 
-| node (11.10) | [koa](http://koajs.com) (2.7) | 11.89 ms | 9.26 ms | 19.09 ms | 49.15 ms | 470.10 ms | 17483.00 | 
-| go (1.11) | [gorilla-mux](http://www.gorillatoolkit.org/pkg/mux) (1.7) | 11.70 ms | 9.26 ms | 20.09 ms | 44.00 ms | 384.78 ms | 12503.67 | 
-| python (3.7) | [falcon](http://falconframework.org) (1.4) | 11.91 ms | 9.48 ms | 21.91 ms | 44.87 ms | 220.90 ms | 9759.33 | 
-| go (1.11) | [gin](http://gin-gonic.github.io/gin) (1.3) | 12.34 ms | 9.60 ms | 22.70 ms | 49.08 ms | 175.50 ms | 9414.33 | 
-| node (11.10) | [muneem](http://github.com/node-muneem/muneem/) (2.4) | 16.65 ms | 9.78 ms | 25.18 ms | 182.12 ms | 773.64 ms | 39996.00 | 
-| go (1.11) | [echo](http://echo.labstack.com) (4.0) | 12.32 ms | 9.81 ms | 22.54 ms | 46.04 ms | 219.78 ms | 9144.33 | 
-| go (1.11) | [iris](http://iris-go.com) (11.1) | 12.78 ms | 9.85 ms | 23.96 ms | 50.84 ms | 191.78 ms | 10402.33 | 
-| node (11.10) | [fastify](http://fastify.io) (2.0) | 16.30 ms | 10.27 ms | 25.15 ms | 163.96 ms | 667.76 ms | 33686.00 | 
-| python (3.7) | [bottle](http://bottlepy.org) (0.12) | 13.86 ms | 10.88 ms | 24.46 ms | 53.40 ms | 381.94 ms | 12990.00 | 
-| go (1.11) | [beego](http://beego.me) (1.11) | 14.19 ms | 10.90 ms | 26.48 ms | 56.87 ms | 187.07 ms | 11189.67 | 
-| node (11.10) | [express](http://expressjs.com) (4.16) | 15.99 ms | 10.90 ms | 24.21 ms | 93.00 ms | 696.62 ms | 31070.00 | 
-| node (11.10) | [restify](http://restify.com) (8.0) | 14.85 ms | 11.62 ms | 21.64 ms | 74.40 ms | 490.86 ms | 20964.67 | 
-| go (1.11) | [gf](http://goframe.org) (1.5) | 14.64 ms | 12.63 ms | 22.96 ms | 50.63 ms | 377.50 ms | 11873.00 | 
-| swift (4.2) | [perfect](http://perfect.org) (3.0) | 13.92 ms | 13.62 ms | 16.70 ms | 23.55 ms | 99.99 ms | 2872.67 | 
-| swift (4.2) | [vapor](http://vapor.codes) (3.0) | 20.64 ms | 13.70 ms | 26.35 ms | 182.76 ms | 1102.60 ms | 51857.33 | 
-| scala (2.12) | [http4s](http://http4s.org) (0.18) | 55.41 ms | 14.68 ms | 32.22 ms | 1367.55 ms | 2526.92 ms | 229914.67 | 
-| python (3.7) | [starlette](http://starlette.io) (0.11) | 18.34 ms | 15.40 ms | 32.32 ms | 57.22 ms | 141.50 ms | 11149.67 | 
-| python (3.7) | [hug](http://hug.rest) (2.4) | 18.37 ms | 15.74 ms | 30.15 ms | 56.31 ms | 234.15 ms | 11230.00 | 
-| python (3.7) | [bocadillo](http://bocadilloproject.github.io) (0.12) | 24.24 ms | 21.15 ms | 41.23 ms | 77.56 ms | 154.92 ms | 14325.33 | 
-| python (3.7) | [fastapi](http://fastapi.tiangolo.com) (0.5) | 26.98 ms | 22.32 ms | 49.65 ms | 85.72 ms | 190.72 ms | 17290.33 | 
-| swift (4.2) | [kitura](http://kitura.io) (2.5) | 37.50 ms | 24.30 ms | 43.86 ms | 440.81 ms | 1526.75 ms | 92049.67 | 
-| python (3.7) | [aiohttp](http://aiohttp.readthedocs.io) (3.5) | 28.01 ms | 25.93 ms | 46.76 ms | 70.89 ms | 165.96 ms | 14185.00 | 
-| node (11.10) | [hapi](http://hapijs.com) (18.1) | 37.48 ms | 27.29 ms | 51.92 ms | 313.51 ms | 1127.61 ms | 60158.00 | 
-| crystal (0.27) | [raze](http://razecr.com) (0.3) | 34.54 ms | 29.48 ms | 49.60 ms | 86.75 ms | 371.46 ms | 17697.33 | 
-| crystal (0.27) | [kemal](http://kemalcr.com) (0.25) | 33.60 ms | 29.50 ms | 47.61 ms | 83.07 ms | 550.24 ms | 20941.00 | 
-| python (3.7) | [molten](http://moltenframework.com) (0.7) | 36.92 ms | 32.02 ms | 57.31 ms | 102.33 ms | 475.49 ms | 21215.67 | 
-| python (3.7) | [flask](http://flask.pocoo.org) (1.0) | 39.94 ms | 34.58 ms | 62.58 ms | 106.39 ms | 499.69 ms | 25099.00 | 
-| crystal (0.27) | [router.cr](http://github.com/tbrand/router.cr) (0.2) | 46.02 ms | 42.11 ms | 70.30 ms | 120.22 ms | 261.50 ms | 21491.00 | 
-| crystal (0.27) | [lucky](http://luckyframework.org) (0.11) | 50.22 ms | 46.17 ms | 69.53 ms | 134.60 ms | 259.76 ms | 20156.33 | 
-| crystal (0.27) | [amber](http://amberframework.org) (0.11) | 48.75 ms | 47.19 ms | 66.97 ms | 123.60 ms | 353.53 ms | 20463.00 | 
-| crystal (0.27) | [orion](http://github.com/obsidian/orion) (1.6) | 49.57 ms | 48.89 ms | 65.54 ms | 102.62 ms | 301.15 ms | 18107.33 | 
-| python (3.7) | [sanic](http://github.com/huge-success/sanic) (18.12) | 59.42 ms | 52.99 ms | 106.31 ms | 184.12 ms | 343.28 ms | 36989.67 | 
-| python (3.7) | [django](http://djangoproject.com) (2.1) | 64.10 ms | 58.07 ms | 93.23 ms | 153.32 ms | 460.86 ms | 24801.33 | 
-| python (3.7) | [quart](http://pgjones.gitlab.io/quart) (0.8) | 71.73 ms | 59.26 ms | 139.26 ms | 221.49 ms | 372.93 ms | 46097.00 | 
-| python (3.7) | [tornado](http://tornadoweb.org) (5.1) | 103.43 ms | 95.79 ms | 143.95 ms | 231.65 ms | 578.27 ms | 39850.00 | 
-| python (3.7) | [responder](http://github.com/kennethreitz/responder) (1.3) | 111.22 ms | 113.92 ms | 175.41 ms | 232.69 ms | 336.46 ms | 50542.33 | 
+| rust (1.32) | [nickel](http://nickel-org.github.io) (0.11) | 0.09 ms | 0.09 ms | 0.13 ms | 0.16 ms | 6.80 ms | 50.00 | 
+| ruby (2.6) | [roda](http://roda.jeremyevans.net) (3.16) | 3.29 ms | 0.18 ms | 11.88 ms | 28.80 ms | 76.28 ms | 6420.67 | 
+| ruby (2.6) | [rack-routing](http://github.com/georgeu2000/rack-routing) (0.0) | 3.90 ms | 0.21 ms | 14.19 ms | 31.97 ms | 80.42 ms | 7326.33 | 
+| ruby (2.6) | [flame](http://github.com/AlexWayfer/flame) (4.18) | 5.77 ms | 0.32 ms | 19.91 ms | 42.84 ms | 105.73 ms | 10019.67 | 
+| ruby (2.6) | [hanami](http://hanamirb.org) (1.3) | 6.87 ms | 0.36 ms | 23.74 ms | 48.93 ms | 118.92 ms | 11751.33 | 
+| php (7.3) | [laravel](http://laravel.com) (5.7) | 128.04 ms | 0.38 ms | 329.27 ms | 2473.38 ms | 6862.49 ms | 434616.33 | 
+| php (7.3) | [lumen](http://lumen.laravel.com) (5.7) | 197.60 ms | 0.39 ms | 318.98 ms | 4193.26 ms | 7187.31 ms | 711536.00 | 
+| rust (1.32) | [iron](http://ironframework.io) (0.6) | 0.41 ms | 0.41 ms | 0.65 ms | 0.93 ms | 56.70 ms | 417.67 | 
+| ruby (2.6) | [sinatra](http://sinatrarb.com) (2.0) | 8.45 ms | 0.52 ms | 27.06 ms | 54.66 ms | 127.99 ms | 13109.67 | 
+| php (7.3) | [zend-framework](http://framework.zend.com) (3.1) | 175.34 ms | 0.75 ms | 347.38 ms | 3718.09 ms | 6761.43 ms | 640861.33 | 
+| php (7.3) | [slim](http://slimframework.com) (3.12) | 145.82 ms | 1.51 ms | 262.34 ms | 3210.07 ms | 5923.88 ms | 537397.67 | 
+| php (7.3) | [symfony](http://symfony.com) (4.2) | 237.14 ms | 1.58 ms | 523.52 ms | 4197.30 ms | 7172.53 ms | 759387.00 | 
+| rust (nightly) | [rocket](http://rocket.rs) (0.4) | 62.59 ms | 1.71 ms | 3.63 ms | 2179.61 ms | 4951.15 ms | 391643.67 | 
+| php (7.3) | [zend-expressive](http://zendframework.github.io/zend-expressive) (3.2) | 119.14 ms | 1.74 ms | 252.35 ms | 2581.11 ms | 7077.76 ms | 452571.67 | 
+| c (11) | [agoo-c](http://github.com/ohler55/agoo-c) (0.3) | 3.26 ms | 3.03 ms | 5.62 ms | 10.10 ms | 88.40 ms | 2256.00 | 
+| rust (1.32) | [actix-web](http://actix.rs) (0.7) | 3.91 ms | 3.10 ms | 7.95 ms | 17.23 ms | 109.78 ms | 4102.00 | 
+| python (3.7) | [japronto](http://github.com/squeaky-pl/japronto) (0.1) | 4.05 ms | 3.31 ms | 8.48 ms | 16.61 ms | 49.67 ms | 3693.67 | 
+| ruby (2.6) | [rails](http://rubyonrails.org) (5.2) | 40.08 ms | 3.34 ms | 122.33 ms | 420.59 ms | 1354.01 ms | 95250.33 | 
+| ruby (2.6) | [agoo](http://github.com/ohler55/agoo) (2.8) | 5.54 ms | 3.78 ms | 8.99 ms | 58.83 ms | 126.93 ms | 9640.33 | 
+| go (1.11) | [fasthttprouter](http://godoc.org/github.com/buaazp/fasthttprouter) (0.1) | 4.27 ms | 3.84 ms | 6.48 ms | 13.49 ms | 159.32 ms | 3670.67 | 
+| python (3.6) | [vibora](http://vibora.io) (0.0) | 4.71 ms | 3.87 ms | 9.45 ms | 17.04 ms | 43.70 ms | 3721.67 | 
+| crystal (0.27) | [onyx](http://github.com/onyxframework/rest) (0.6) | 4.56 ms | 4.37 ms | 7.67 ms | 14.87 ms | 35.20 ms | 2845.67 | 
+| cpp (11.0) | [evhtp](http://github.com/criticalstack/libevhtp) (1.2) | 3.91 ms | 4.39 ms | 5.59 ms | 8.31 ms | 103.03 ms | 1982.00 | 
+| crystal (0.27) | [spider-gazelle](http://spider-gazelle.net) (1.4) | 5.05 ms | 4.46 ms | 9.36 ms | 16.92 ms | 40.78 ms | 3377.00 | 
+| rust (1.32) | [gotham](http://gotham.rs) (0.3) | 5.18 ms | 4.62 ms | 9.68 ms | 20.15 ms | 193.66 ms | 5038.33 | 
+| node (11.10) | [restana](http://github.com/jkyberneees/ana) (2.9) | 5.64 ms | 4.74 ms | 9.19 ms | 17.12 ms | 211.74 ms | 5976.33 | 
+| nim (0.19) | [jester](http://github.com/dom96/jester) (0.4) | 5.36 ms | 5.30 ms | 8.21 ms | 15.27 ms | 42.75 ms | 2851.33 | 
+| node (11.10) | [polka](http://github.com/lukeed/polka) (0.5) | 6.99 ms | 5.53 ms | 10.60 ms | 19.70 ms | 236.80 ms | 7253.00 | 
+| node (11.10) | [rayo](http://rayo.js.org) (1.2) | 7.92 ms | 5.78 ms | 11.21 ms | 26.80 ms | 392.72 ms | 13815.00 | 
+| go (1.11) | [iris](http://iris-go.com) (11.1) | 7.06 ms | 5.80 ms | 11.60 ms | 22.82 ms | 51.58 ms | 3991.33 | 
+| go (1.11) | [muxie](http://godoc.org/github.com/kataras/muxie) (1.0) | 7.21 ms | 5.86 ms | 12.04 ms | 24.01 ms | 143.90 ms | 4553.67 | 
+| go (1.11) | [chi](http://github.com/go-chi/chi) (4.0) | 7.78 ms | 5.93 ms | 12.16 ms | 25.91 ms | 325.10 ms | 11380.67 | 
+| c (99) | [kore](http://kore.io) (3.1) | 6.34 ms | 6.05 ms | 10.42 ms | 13.29 ms | 1323.33 ms | 14250.00 | 
+| go (1.11) | [kami](http://github.com/guregu/kami) (2.2) | 7.65 ms | 6.18 ms | 12.02 ms | 24.09 ms | 309.14 ms | 8599.00 | 
+| go (1.11) | [echo](http://echo.labstack.com) (4.0) | 7.71 ms | 6.29 ms | 12.92 ms | 25.65 ms | 166.25 ms | 5307.67 | 
+| go (1.11) | [beego](http://beego.me) (1.11) | 7.71 ms | 6.38 ms | 12.69 ms | 24.49 ms | 163.84 ms | 5318.67 | 
+| csharp (7.3) | [aspnetcore](http://docs.microsoft.com/en-us/aspnet/index) (2.2) | 7.68 ms | 6.41 ms | 10.52 ms | 23.38 ms | 423.87 ms | 11046.00 | 
+| java (8) | [act](http://actframework.org) (1.8) | 7.76 ms | 6.71 ms | 13.18 ms | 29.51 ms | 151.25 ms | 6041.00 | 
+| go (1.11) | [gin](http://gin-gonic.github.io/gin) (1.3) | 8.59 ms | 6.89 ms | 14.74 ms | 30.75 ms | 189.22 ms | 5934.67 | 
+| go (1.11) | [gorilla-mux](http://www.gorillatoolkit.org/pkg/mux) (1.7) | 9.32 ms | 7.41 ms | 15.72 ms | 32.20 ms | 259.26 ms | 9744.33 | 
+| node (11.10) | [fastify](http://fastify.io) (2.0) | 10.04 ms | 7.55 ms | 13.71 ms | 47.60 ms | 466.87 ms | 18252.00 | 
+| scala (2.12) | [akkahttp](http://akka.io) (10.1) | 156.00 ms | 7.85 ms | 26.86 ms | 4068.61 ms | 6902.77 ms | 681423.67 | 
+| node (11.10) | [muneem](http://github.com/node-muneem/muneem/) (2.4) | 11.27 ms | 7.88 ms | 16.72 ms | 86.26 ms | 502.18 ms | 22437.00 | 
+| node (11.10) | [foxify](http://foxify.js.org) (0.10) | 8.98 ms | 8.04 ms | 13.60 ms | 25.61 ms | 340.96 ms | 11450.33 | 
+| python (3.7) | [falcon](http://falconframework.org) (1.4) | 10.35 ms | 8.34 ms | 19.32 ms | 35.54 ms | 215.91 ms | 8384.00 | 
+| node (11.10) | [express](http://expressjs.com) (4.16) | 10.18 ms | 8.75 ms | 14.96 ms | 29.45 ms | 428.88 ms | 13171.67 | 
+| node (11.10) | [koa](http://koajs.com) (2.7) | 10.90 ms | 9.04 ms | 15.01 ms | 41.07 ms | 502.51 ms | 19357.67 | 
+| python (3.7) | [bottle](http://bottlepy.org) (0.12) | 11.89 ms | 9.25 ms | 23.25 ms | 47.15 ms | 219.00 ms | 10216.00 | 
+| go (1.11) | [gf](http://goframe.org) (1.5) | 10.59 ms | 9.60 ms | 15.58 ms | 31.73 ms | 238.08 ms | 6590.67 | 
+| node (11.10) | [restify](http://restify.com) (8.0) | 11.20 ms | 9.63 ms | 15.28 ms | 34.49 ms | 280.02 ms | 9280.00 | 
+| swift (4.2) | [perfect](http://perfect.org) (3.0) | 12.19 ms | 12.21 ms | 14.68 ms | 19.06 ms | 71.72 ms | 2418.33 | 
+| python (3.7) | [starlette](http://starlette.io) (0.11) | 14.53 ms | 12.61 ms | 24.98 ms | 36.37 ms | 70.31 ms | 7376.67 | 
+| swift (4.2) | [vapor](http://vapor.codes) (3.0) | 18.51 ms | 13.32 ms | 23.79 ms | 144.35 ms | 1080.15 ms | 47467.67 | 
+| python (3.7) | [hug](http://hug.rest) (2.4) | 18.02 ms | 13.98 ms | 35.59 ms | 63.33 ms | 275.14 ms | 12729.67 | 
+| scala (2.12) | [http4s](http://http4s.org) (0.18) | 16.21 ms | 14.81 ms | 29.45 ms | 51.13 ms | 192.84 ms | 11213.67 | 
+| python (3.7) | [bocadillo](http://bocadilloproject.github.io) (0.12) | 19.86 ms | 18.34 ms | 32.23 ms | 47.14 ms | 85.26 ms | 9257.00 | 
+| python (3.7) | [fastapi](http://fastapi.tiangolo.com) (0.5) | 22.45 ms | 19.65 ms | 38.75 ms | 57.18 ms | 105.55 ms | 11879.67 | 
+| python (3.7) | [aiohttp](http://aiohttp.readthedocs.io) (3.5) | 23.70 ms | 21.72 ms | 37.75 ms | 55.01 ms | 89.43 ms | 9888.00 | 
+| node (11.10) | [hapi](http://hapijs.com) (18.1) | 37.45 ms | 22.10 ms | 39.20 ms | 543.85 ms | 1409.01 ms | 92490.33 | 
+| swift (4.2) | [kitura](http://kitura.io) (2.5) | 27.40 ms | 22.84 ms | 34.32 ms | 121.77 ms | 1056.58 ms | 41247.00 | 
+| crystal (0.27) | [router.cr](http://github.com/tbrand/router.cr) (0.2) | 27.11 ms | 24.73 ms | 38.76 ms | 46.89 ms | 123.85 ms | 7252.33 | 
+| crystal (0.27) | [lucky](http://luckyframework.org) (0.11) | 31.48 ms | 27.81 ms | 43.87 ms | 114.78 ms | 325.49 ms | 17923.33 | 
+| crystal (0.27) | [kemal](http://kemalcr.com) (0.25) | 32.22 ms | 29.28 ms | 42.97 ms | 54.85 ms | 262.63 ms | 11874.00 | 
+| python (3.7) | [molten](http://moltenframework.com) (0.7) | 36.36 ms | 29.53 ms | 67.85 ms | 108.10 ms | 331.49 ms | 20761.00 | 
+| python (3.7) | [flask](http://flask.pocoo.org) (1.0) | 32.92 ms | 30.09 ms | 49.82 ms | 72.67 ms | 322.68 ms | 14821.67 | 
+| crystal (0.27) | [orion](http://github.com/obsidian/orion) (1.6) | 36.69 ms | 32.48 ms | 51.19 ms | 69.54 ms | 707.35 ms | 26679.67 | 
+| crystal (0.27) | [raze](http://razecr.com) (0.3) | 32.39 ms | 32.91 ms | 42.73 ms | 50.95 ms | 179.16 ms | 8358.67 | 
+| crystal (0.27) | [amber](http://amberframework.org) (0.11) | 36.62 ms | 36.58 ms | 47.20 ms | 54.92 ms | 242.45 ms | 9089.00 | 
+| python (3.7) | [sanic](http://github.com/huge-success/sanic) (18.12) | 45.77 ms | 39.12 ms | 79.52 ms | 131.00 ms | 210.31 ms | 25399.00 | 
+| python (3.7) | [django](http://djangoproject.com) (2.1) | 61.26 ms | 47.75 ms | 119.65 ms | 180.86 ms | 399.58 ms | 36766.00 | 
+| python (3.7) | [quart](http://pgjones.gitlab.io/quart) (0.8) | 64.31 ms | 57.95 ms | 104.58 ms | 144.60 ms | 204.43 ms | 30446.00 | 
+| python (3.7) | [responder](http://github.com/kennethreitz/responder) (1.3) | 79.00 ms | 70.16 ms | 137.74 ms | 176.76 ms | 296.20 ms | 39801.33 | 
+| python (3.7) | [tornado](http://tornadoweb.org) (5.1) | 90.30 ms | 87.85 ms | 120.76 ms | 149.11 ms | 573.94 ms | 24812.00 | 
 
 ### Requests per seconds
 
@@ -181,16 +182,16 @@ CPU Cores: 8
 #### Ranking (top 5)
 
 
-:one: (actix-web) (rust)
+:one: (agoo-c) (c)
 
 
 :two: (japronto) (python)
 
 
-:three: (agoo-c) (c)
+:three: (actix-web) (rust)
 
 
-:four: (vibora) (python)
+:four: (agoo) (ruby)
 
 
 :five: (evhtp) (cpp)
@@ -200,78 +201,79 @@ CPU Cores: 8
 
 | Language (Runtime) | Framework (Middleware) | Requests / s | Throughput |
 |---------------------------|---------------------------|----------------:|---------:|
-| rust (1.32) | [actix-web](http://actix.rs) (0.7) | 235681.67 | 267.92 MB |
-| python (3.7) | [japronto](http://github.com/squeaky-pl/japronto) (0.1) | 234877.67 | 281.22 MB |
-| c (11) | [agoo-c](http://github.com/ohler55/agoo-c) (0.3) | 198443.00 | 114.78 MB |
-| python (3.6) | [vibora](http://vibora.io) (0.0) | 190256.67 | 216.03 MB |
-| cpp (11.0) | [evhtp](http://github.com/criticalstack/libevhtp) (1.2) | 172818.00 | 167.75 MB |
-| nim (0.19) | [jester](http://github.com/dom96/jester) (0.4) | 162171.00 | 326.03 MB |
-| crystal (0.27) | [onyx](http://github.com/onyxframework/rest) (0.6) | 158848.67 | 149.31 MB |
-| go (1.11) | [fasthttprouter](http://godoc.org/github.com/buaazp/fasthttprouter) (0.1) | 156037.00 | 251.94 MB |
-| java (8) | [act](http://actframework.org) (1.8) | 155696.00 | 303.85 MB |
-| rust (1.32) | [gotham](http://gotham.rs) (0.3) | 149142.00 | 304.28 MB |
-| crystal (0.27) | [spider-gazelle](http://spider-gazelle.net) (1.4) | 142889.67 | 152.73 MB |
-| node (11.10) | [restana](http://github.com/jkyberneees/ana) (2.9) | 134224.33 | 201.21 MB |
-| rust (1.32) | [iron](http://ironframework.io) (0.6) | 125677.33 | 158.17 MB |
-| node (11.10) | [rayo](http://rayo.js.org) (1.2) | 117494.00 | 176.10 MB |
-| ruby (2.6) | [agoo](http://github.com/ohler55/agoo) (2.8) | 116054.67 | 67.17 MB |
-| go (1.11) | [muxie](http://godoc.org/github.com/kataras/muxie) (1.0) | 113809.00 | 152.14 MB |
-| node (11.10) | [polka](http://github.com/lukeed/polka) (0.5) | 113665.67 | 170.52 MB |
-| rust (1.32) | [nickel](http://nickel-org.github.io) (0.11) | 108288.00 | 215.32 MB |
-| go (1.11) | [chi](http://github.com/go-chi/chi) (4.0) | 106477.33 | 142.22 MB |
-| csharp (7.3) | [aspnetcore](http://docs.microsoft.com/en-us/aspnet/index) (2.2) | 101061.33 | 164.67 MB |
-| node (11.10) | [foxify](http://foxify.js.org) (0.10) | 96812.33 | 203.60 MB |
-| node (11.10) | [fastify](http://fastify.io) (2.0) | 93808.67 | 227.60 MB |
-| node (11.10) | [koa](http://koajs.com) (2.7) | 93444.67 | 197.92 MB |
-| go (1.11) | [gorilla-mux](http://www.gorillatoolkit.org/pkg/mux) (1.7) | 90003.67 | 122.08 MB |
-| python (3.7) | [falcon](http://falconframework.org) (1.4) | 88052.33 | 226.33 MB |
-| node (11.10) | [muneem](http://github.com/node-muneem/muneem/) (2.4) | 87649.33 | 131.45 MB |
-| go (1.11) | [gin](http://gin-gonic.github.io/gin) (1.3) | 85827.00 | 150.61 MB |
-| go (1.11) | [echo](http://echo.labstack.com) (4.0) | 82217.00 | 144.38 MB |
-| go (1.11) | [iris](http://iris-go.com) (11.1) | 80503.33 | 106.67 MB |
-| node (11.10) | [restify](http://restify.com) (8.0) | 75733.00 | 132.97 MB |
-| node (11.10) | [express](http://expressjs.com) (4.16) | 75703.67 | 185.48 MB |
-| python (3.7) | [bottle](http://bottlepy.org) (0.12) | 75607.00 | 186.40 MB |
-| go (1.11) | [beego](http://beego.me) (1.11) | 74268.33 | 100.26 MB |
-| swift (4.2) | [perfect](http://perfect.org) (3.0) | 72588.00 | 68.27 MB |
-| go (1.11) | [gf](http://goframe.org) (1.5) | 70148.33 | 106.78 MB |
-| scala (2.12) | [http4s](http://http4s.org) (0.18) | 64501.00 | 113.06 MB |
-| swift (4.2) | [vapor](http://vapor.codes) (3.0) | 61408.67 | 102.29 MB |
-| python (3.7) | [starlette](http://starlette.io) (0.11) | 56708.33 | 122.07 MB |
-| scala (2.12) | [akkahttp](http://akka.io) (10.1) | 55633.33 | 119.46 MB |
-| python (3.7) | [hug](http://hug.rest) (2.4) | 55185.33 | 136.84 MB |
-| php (7.3) | [zend-framework](http://framework.zend.com) (3.1) | 49126.33 | 244.33 MB |
-| python (3.7) | [bocadillo](http://bocadilloproject.github.io) (0.12) | 42737.00 | 82.62 MB |
-| php (7.3) | [symfony](http://symfony.com) (4.2) | 40354.67 | 200.69 MB |
-| rust (nightly) | [rocket](http://rocket.rs) (0.4) | 39639.33 | 62.59 MB |
-| python (3.7) | [fastapi](http://fastapi.tiangolo.com) (0.5) | 39036.00 | 84.45 MB |
-| php (7.3) | [lumen](http://lumen.laravel.com) (5.7) | 37575.67 | 195.65 MB |
-| php (7.3) | [laravel](http://laravel.com) (5.7) | 36690.00 | 191.34 MB |
-| python (3.7) | [aiohttp](http://aiohttp.readthedocs.io) (3.5) | 35977.00 | 81.59 MB |
-| swift (4.2) | [kitura](http://kitura.io) (2.5) | 35154.33 | 65.19 MB |
-| php (7.3) | [zend-expressive](http://zendframework.github.io/zend-expressive) (3.2) | 33371.67 | 166.14 MB |
-| node (11.10) | [hapi](http://hapijs.com) (18.1) | 32316.00 | 83.88 MB |
-| c (99) | [kore](http://kore.io) (3.1) | 30958.33 | 84.19 MB |
-| php (7.3) | [slim](http://slimframework.com) (3.12) | 30696.67 | 152.82 MB |
-| crystal (0.27) | [kemal](http://kemalcr.com) (0.25) | 29696.67 | 48.54 MB |
-| crystal (0.27) | [raze](http://razecr.com) (0.3) | 29259.33 | 27.50 MB |
-| ruby (2.6) | [roda](http://roda.jeremyevans.net) (3.16) | 28106.00 | 26.86 MB |
-| python (3.7) | [molten](http://moltenframework.com) (0.7) | 27723.67 | 51.59 MB |
-| python (3.7) | [flask](http://flask.pocoo.org) (1.0) | 25450.00 | 62.70 MB |
-| crystal (0.27) | [router.cr](http://github.com/tbrand/router.cr) (0.2) | 22162.67 | 20.85 MB |
-| ruby (2.6) | [rack-routing](http://github.com/georgeu2000/rack-routing) (0.0) | 21140.00 | 12.22 MB |
-| crystal (0.27) | [orion](http://github.com/obsidian/orion) (1.6) | 20663.67 | 33.71 MB |
-| crystal (0.27) | [lucky](http://luckyframework.org) (0.11) | 20381.33 | 24.98 MB |
-| crystal (0.27) | [amber](http://amberframework.org) (0.11) | 20356.33 | 37.28 MB |
-| python (3.7) | [sanic](http://github.com/huge-success/sanic) (18.12) | 17382.00 | 31.01 MB |
-| ruby (2.6) | [flame](http://github.com/AlexWayfer/flame) (4.18) | 15402.33 | 8.90 MB |
-| python (3.7) | [django](http://djangoproject.com) (2.1) | 15329.67 | 44.46 MB |
-| python (3.7) | [quart](http://pgjones.gitlab.io/quart) (0.8) | 14632.67 | 29.22 MB |
-| ruby (2.6) | [hanami](http://hanamirb.org) (1.3) | 11205.00 | 84.96 MB |
-| ruby (2.6) | [sinatra](http://sinatrarb.com) (2.0) | 10067.00 | 26.19 MB |
-| python (3.7) | [tornado](http://tornadoweb.org) (5.1) | 9379.33 | 27.81 MB |
-| python (3.7) | [responder](http://github.com/kennethreitz/responder) (1.3) | 8901.00 | 19.43 MB |
-| ruby (2.6) | [rails](http://rubyonrails.org) (5.2) | 2496.00 | 7.65 MB |
+| c (11) | [agoo-c](http://github.com/ohler55/agoo-c) (0.3) | 293363.00 | 169.64 MB |
+| python (3.7) | [japronto](http://github.com/squeaky-pl/japronto) (0.1) | 254171.33 | 304.12 MB |
+| rust (1.32) | [actix-web](http://actix.rs) (0.7) | 249474.33 | 283.70 MB |
+| ruby (2.6) | [agoo](http://github.com/ohler55/agoo) (2.8) | 233725.33 | 135.18 MB |
+| cpp (11.0) | [evhtp](http://github.com/criticalstack/libevhtp) (1.2) | 223440.00 | 216.64 MB |
+| python (3.6) | [vibora](http://vibora.io) (0.0) | 221186.33 | 251.28 MB |
+| go (1.11) | [fasthttprouter](http://godoc.org/github.com/buaazp/fasthttprouter) (0.1) | 218982.67 | 352.41 MB |
+| crystal (0.27) | [onyx](http://github.com/onyxframework/rest) (0.6) | 206274.00 | 193.99 MB |
+| nim (0.19) | [jester](http://github.com/dom96/jester) (0.4) | 196048.67 | 393.81 MB |
+| crystal (0.27) | [spider-gazelle](http://spider-gazelle.net) (1.4) | 194882.33 | 208.06 MB |
+| rust (1.32) | [gotham](http://gotham.rs) (0.3) | 193953.00 | 396.67 MB |
+| node (11.10) | [restana](http://github.com/jkyberneees/ana) (2.9) | 174640.33 | 261.84 MB |
+| java (8) | [act](http://actframework.org) (1.8) | 166702.33 | 325.74 MB |
+| rust (1.32) | [iron](http://ironframework.io) (0.6) | 146930.67 | 184.93 MB |
+| node (11.10) | [polka](http://github.com/lukeed/polka) (0.5) | 141610.33 | 211.96 MB |
+| go (1.11) | [iris](http://iris-go.com) (11.1) | 138650.33 | 185.74 MB |
+| node (11.10) | [rayo](http://rayo.js.org) (1.2) | 136187.67 | 203.92 MB |
+| go (1.11) | [muxie](http://godoc.org/github.com/kataras/muxie) (1.0) | 135772.67 | 180.95 MB |
+| go (1.11) | [chi](http://github.com/go-chi/chi) (4.0) | 134444.67 | 180.35 MB |
+| go (1.11) | [kami](http://github.com/guregu/kami) (2.2) | 130610.33 | 173.51 MB |
+| csharp (7.3) | [aspnetcore](http://docs.microsoft.com/en-us/aspnet/index) (2.2) | 129602.00 | 211.07 MB |
+| go (1.11) | [echo](http://echo.labstack.com) (4.0) | 128019.33 | 224.85 MB |
+| go (1.11) | [beego](http://beego.me) (1.11) | 127435.33 | 171.96 MB |
+| node (11.10) | [fastify](http://fastify.io) (2.0) | 121120.00 | 311.50 MB |
+| node (11.10) | [muneem](http://github.com/node-muneem/muneem/) (2.4) | 120945.33 | 181.07 MB |
+| go (1.11) | [gin](http://gin-gonic.github.io/gin) (1.3) | 116748.33 | 204.93 MB |
+| node (11.10) | [foxify](http://foxify.js.org) (0.10) | 116381.67 | 244.49 MB |
+| go (1.11) | [gorilla-mux](http://www.gorillatoolkit.org/pkg/mux) (1.7) | 109420.00 | 146.37 MB |
+| node (11.10) | [koa](http://koajs.com) (2.7) | 103239.00 | 218.31 MB |
+| node (11.10) | [express](http://expressjs.com) (4.16) | 102625.00 | 251.21 MB |
+| python (3.7) | [falcon](http://falconframework.org) (1.4) | 100991.33 | 259.59 MB |
+| go (1.11) | [gf](http://goframe.org) (1.5) | 95433.67 | 145.15 MB |
+| rust (1.32) | [nickel](http://nickel-org.github.io) (0.11) | 91424.67 | 181.38 MB |
+| node (11.10) | [restify](http://restify.com) (8.0) | 91046.67 | 159.91 MB |
+| python (3.7) | [bottle](http://bottlepy.org) (0.12) | 89635.33 | 220.78 MB |
+| swift (4.2) | [perfect](http://perfect.org) (3.0) | 80475.67 | 75.66 MB |
+| python (3.7) | [starlette](http://starlette.io) (0.11) | 68818.67 | 148.15 MB |
+| scala (2.12) | [akkahttp](http://akka.io) (10.1) | 68294.00 | 146.77 MB |
+| swift (4.2) | [vapor](http://vapor.codes) (3.0) | 68173.33 | 114.02 MB |
+| php (7.3) | [zend-expressive](http://zendframework.github.io/zend-expressive) (3.2) | 67338.33 | 334.50 MB |
+| scala (2.12) | [http4s](http://http4s.org) (0.18) | 65910.00 | 115.42 MB |
+| php (7.3) | [slim](http://slimframework.com) (3.12) | 63954.67 | 317.84 MB |
+| php (7.3) | [zend-framework](http://framework.zend.com) (3.1) | 60695.00 | 301.27 MB |
+| python (3.7) | [hug](http://hug.rest) (2.4) | 60202.33 | 149.09 MB |
+| php (7.3) | [lumen](http://lumen.laravel.com) (5.7) | 59355.33 | 308.10 MB |
+| php (7.3) | [symfony](http://symfony.com) (4.2) | 55797.67 | 277.40 MB |
+| rust (nightly) | [rocket](http://rocket.rs) (0.4) | 51544.67 | 81.82 MB |
+| python (3.7) | [bocadillo](http://bocadilloproject.github.io) (0.12) | 50273.67 | 97.04 MB |
+| php (7.3) | [laravel](http://laravel.com) (5.7) | 50208.00 | 261.57 MB |
+| c (99) | [kore](http://kore.io) (3.1) | 49829.33 | 135.23 MB |
+| python (3.7) | [fastapi](http://fastapi.tiangolo.com) (0.5) | 44981.67 | 97.08 MB |
+| python (3.7) | [aiohttp](http://aiohttp.readthedocs.io) (3.5) | 42208.67 | 95.74 MB |
+| node (11.10) | [hapi](http://hapijs.com) (18.1) | 41304.00 | 106.78 MB |
+| swift (4.2) | [kitura](http://kitura.io) (2.5) | 39604.67 | 73.43 MB |
+| ruby (2.6) | [roda](http://roda.jeremyevans.net) (3.16) | 38902.33 | 37.10 MB |
+| crystal (0.27) | [router.cr](http://github.com/tbrand/router.cr) (0.2) | 36598.67 | 34.36 MB |
+| ruby (2.6) | [rack-routing](http://github.com/georgeu2000/rack-routing) (0.0) | 32851.67 | 18.93 MB |
+| crystal (0.27) | [lucky](http://luckyframework.org) (0.11) | 32377.00 | 39.74 MB |
+| crystal (0.27) | [raze](http://razecr.com) (0.3) | 31317.00 | 29.35 MB |
+| crystal (0.27) | [kemal](http://kemalcr.com) (0.25) | 31119.67 | 50.70 MB |
+| python (3.7) | [flask](http://flask.pocoo.org) (1.0) | 30142.33 | 74.21 MB |
+| python (3.7) | [molten](http://moltenframework.com) (0.7) | 29128.00 | 54.14 MB |
+| crystal (0.27) | [orion](http://github.com/obsidian/orion) (1.6) | 27567.00 | 44.91 MB |
+| crystal (0.27) | [amber](http://amberframework.org) (0.11) | 26965.67 | 49.23 MB |
+| python (3.7) | [sanic](http://github.com/huge-success/sanic) (18.12) | 22366.00 | 39.86 MB |
+| ruby (2.6) | [flame](http://github.com/AlexWayfer/flame) (4.18) | 22184.67 | 12.81 MB |
+| ruby (2.6) | [hanami](http://hanamirb.org) (1.3) | 18576.33 | 140.35 MB |
+| python (3.7) | [django](http://djangoproject.com) (2.1) | 17027.00 | 49.32 MB |
+| python (3.7) | [quart](http://pgjones.gitlab.io/quart) (0.8) | 15538.67 | 30.99 MB |
+| ruby (2.6) | [sinatra](http://sinatrarb.com) (2.0) | 15133.00 | 39.23 MB |
+| python (3.7) | [responder](http://github.com/kennethreitz/responder) (1.3) | 12628.33 | 27.51 MB |
+| python (3.7) | [tornado](http://tornadoweb.org) (5.1) | 10817.33 | 32.01 MB |
+| ruby (2.6) | [rails](http://rubyonrails.org) (5.2) | 3462.00 | 10.62 MB |
 <!-- Result till here -->
 
 ## How to contribute ?

--- a/go/kami/Dockerfile
+++ b/go/kami/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.11.5
+
+WORKDIR /go/src/app
+COPY main.go go.mod ./
+
+ENV GO111MODULE=on
+RUN go build .
+
+ENV GOJI_BIND "0.0.0.0:3000"
+EXPOSE 3000
+CMD [ "./main" ]

--- a/go/kami/go.mod
+++ b/go/kami/go.mod
@@ -1,8 +1,3 @@
 module main
 
-require (
-	github.com/dimfeld/httptreemux v5.0.1+incompatible // indirect
-	github.com/guregu/kami v2.2.1+incompatible
-	github.com/zenazn/goji v0.9.0 // indirect
-	golang.org/x/net v0.0.0-20190226193003-66a96c8a540e // indirect
-)
+require github.com/guregu/kami v2.2.1

--- a/go/kami/go.mod
+++ b/go/kami/go.mod
@@ -1,0 +1,8 @@
+module main
+
+require (
+	github.com/dimfeld/httptreemux v5.0.1+incompatible // indirect
+	github.com/guregu/kami v2.2.1+incompatible
+	github.com/zenazn/goji v0.9.0 // indirect
+	golang.org/x/net v0.0.0-20190226193003-66a96c8a540e // indirect
+)

--- a/go/kami/main.go
+++ b/go/kami/main.go
@@ -13,7 +13,7 @@ func Index(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func GetUser(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	id := kami.Param(ctx, "name")
+	id := kami.Param(ctx, "id")
 	fmt.Fprintf(w, id)
 
 }

--- a/go/kami/main.go
+++ b/go/kami/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/guregu/kami"
+)
+
+func Index(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "")
+}
+
+func GetUser(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	id := kami.Param(ctx, "name")
+	fmt.Fprintf(w, id)
+
+}
+
+func CreateUser(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "")
+}
+
+func main() {
+	kami.Get("/", Index)
+	kami.Get("/user/:id", GetUser)
+	kami.Post("/user", CreateUser)
+	kami.Serve()
+}

--- a/neph.yaml
+++ b/neph.yaml
@@ -72,6 +72,7 @@ go:
     - beego
     - muxie
     - chi
+    - kami
 
 swift:
   depends_on:
@@ -346,6 +347,11 @@ chi:
   commands:
     - docker build -t chi .
   dir: go/chi
+
+kami:
+  commands:
+    - docker build -t kami .
+  dir: go/kami
 
 vapor:
   commands:


### PR DESCRIPTION
Hi @guregu,

This `PR` addresses #663

I've added `kami` in this benchmark.

Could you check our implementation ?

Results found (docker on 4 x CPU / 8gb)

| Language (Runtime) | Framework (Middleware) | Average | 50th percentile | 90th percentile | 99th percentile | 99.9th percentile | Standard deviation |
|---------------------------|---------------------------|----------------:|----------------:|----------------:|----------------:|----------------:|----------------:|
| go (1.11) | [fasthttprouter](http://godoc.org/github.com/buaazp/fasthttprouter) (0.1) | 5.55 ms | 5.05 ms | 8.53 ms | 14.78 ms | 142.99 ms | 2863.00 | 
| go (1.11) | [chi](http://github.com/go-chi/chi) (4.0) | 13.00 ms | 9.39 ms | 21.24 ms | 118.09 ms | 427.88 ms | 21244.67 | 
| go (1.11) | [muxie](http://godoc.org/github.com/kataras/muxie) (1.0) | 11.41 ms | 9.59 ms | 15.76 ms | 73.15 ms | 335.53 ms | 14806.33 | 
| go (1.11) | [iris](http://iris-go.com) (11.1) | 12.04 ms | 9.93 ms | 16.93 ms | 68.31 ms | 523.91 ms | 19680.00 | 
| go (1.11) | [gin](http://gin-gonic.github.io/gin) (1.3) | 12.55 ms | 10.19 ms | 18.48 ms | 83.77 ms | 388.75 ms | 16719.67 | 
| go (1.11) | [echo](http://echo.labstack.com) (4.0) | 14.16 ms | 10.32 ms | 21.00 ms | 129.89 ms | 482.05 ms | 24880.33 | 
| go (1.11) | [kami](http://github.com/guregu/kami) (2.2) | 15.06 ms | 10.73 ms | 24.93 ms | 139.06 ms | 403.63 ms | 24584.00 | 
| go (1.11) | [beego](http://beego.me) (1.11) | 13.87 ms | 10.80 ms | 22.94 ms | 106.79 ms | 357.95 ms | 19435.00 | 
| go (1.11) | [gorilla-mux](http://www.gorillatoolkit.org/pkg/mux) (1.7) | 16.00 ms | 11.04 ms | 30.21 ms | 132.70 ms | 380.82 ms | 24787.33 | 
| go (1.11) | [gf](http://goframe.org) (1.5) | 16.04 ms | 13.33 ms | 22.05 ms | 106.91 ms | 433.62 ms | 18551.00 |

