### PR TITLE
roda use 3.17 not 3.16

### DIFF
--- a/FRAMEWORKS.yml
+++ b/FRAMEWORKS.yml
@@ -9,7 +9,7 @@ ruby:
     language: "2.6"
   roda:
     website: roda.jeremyevans.net
-    version: "3.16"
+    version: "3.17"
     language: "2.6"
   rack-routing:
     github: georgeu2000/rack-routing


### PR DESCRIPTION
Hi,

This `PR` fix `roda` **version** show in `README`

Regards,