### PR TITLE
Upgrade node

### DIFF
--- a/node/express/Dockerfile
+++ b/node/express/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.10.0
+FROM node:11.10.1
 
 RUN npm -g install pm2
 

--- a/node/fastify/Dockerfile
+++ b/node/fastify/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.10.0
+FROM node:11.10.1
 
 RUN npm -g install pm2
 

--- a/node/foxify/Dockerfile
+++ b/node/foxify/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.10.0
+FROM node:11.10.1
 
 RUN npm -g install pm2
 

--- a/node/hapi/Dockerfile
+++ b/node/hapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.10.0
+FROM node:11.10.1
 
 RUN npm -g install pm2
 

--- a/node/koa/Dockerfile
+++ b/node/koa/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.10.0
+FROM node:11.10.1
 
 RUN npm -g install pm2
 

--- a/node/muneem/Dockerfile
+++ b/node/muneem/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.10.0
+FROM node:11.10.1
 
 RUN npm -g install pm2
 

--- a/node/polka/Dockerfile
+++ b/node/polka/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.10.0
+FROM node:11.10.1
 
 RUN npm -g install pm2
 

--- a/node/rayo/Dockerfile
+++ b/node/rayo/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.10.0
+FROM node:11.10.1
 
 RUN npm -g install pm2
 

--- a/node/restana/Dockerfile
+++ b/node/restana/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.10.0
+FROM node:11.10.1
 
 RUN npm -g install pm2
 

--- a/node/restify/Dockerfile
+++ b/node/restify/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.10.0
+FROM node:11.10.1
 
 RUN npm -g install pm2
 

--- a/node/turbo_polka/Dockerfile
+++ b/node/turbo_polka/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.10.0
+FROM node:11.10.1
 
 RUN npm -g install pm2
 


### PR DESCRIPTION
Hi,

This `PR` updates all `rust` implementations to use `node` `1.10.1`

Only for `docker` in **development**

Regards,