### PR TITLE
surround travis regexp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 # Avoid bots branches
 branches:
   only:
-    - ^(?!.*\/).*$
-    - master
+    - /^(?!.*\/).*$/
     
 # Exit build if not necessary
 before_install:


### PR DESCRIPTION
Hi,

This `PR` fix travis builds.

Before : Only **master** was built

After : Only human branches (not containing **/**)

Regards,