### PR TITLE
Test pattern

### DIFF
--- a/csharp/aspnetcore/Startup.cs
+++ b/csharp/aspnetcore/Startup.cs
@@ -20,7 +20,7 @@ namespace aspnetcore
                     return context.Response.WriteAsync("");
                 });
 
-                routes.MapGet("user/{id}", context => {
+                routes.MapGet("user/{id:int}", context => {
                     var id = context.GetRouteValue("id").ToString();
                     return context.Response.WriteAsync(id);
                 });

--- a/go/gorilla-mux/go.mod
+++ b/go/gorilla-mux/go.mod
@@ -1,6 +1,3 @@
 module main
 
-require (
-	github.com/gorilla/context v1.1.1
-	github.com/gorilla/mux v1.7.1
-)
+require github.com/gorilla/mux v1.7.1

--- a/go/gorilla-mux/main.go
+++ b/go/gorilla-mux/main.go
@@ -14,7 +14,7 @@ func main() {
 			w.Write([]byte(""))
 		}
 	})
-	r.HandleFunc("/user/{id}", func(w http.ResponseWriter, r *http.Request) {
+	r.HandleFunc("/user/{id:[0-9]+}", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "GET" {
 			vars := mux.Vars(r)
 			w.Write([]byte(vars["id"]))

--- a/go/violetear/main.go
+++ b/go/violetear/main.go
@@ -20,7 +20,7 @@ func showEmpty(w http.ResponseWriter, r *http.Request) {
 func main() {
 	router := violetear.New()
 
-	router.AddRegex(":id", `\d+`)
+	router.AddRegex(":id", `[0-9]+`)
 
 	router.HandleFunc("/", showEmpty, "GET")
 	router.HandleFunc("/user/:id", showId, "GET")

--- a/node/express/app.js
+++ b/node/express/app.js
@@ -6,7 +6,7 @@ app.get('/', function (req, res) {
   res.send('')
 })
 
-app.get('/user/:id', function (req, res) {
+app.get('/user/:id(\\d+)', function (req, res) {
   res.send(req.params.id)
 })
 

--- a/node/express/app.js
+++ b/node/express/app.js
@@ -6,7 +6,7 @@ app.get('/', function (req, res) {
   res.send('')
 })
 
-app.get('/user/:id(\\d+)', function (req, res) {
+app.get('/user/:id([0-9]+)', function (req, res) {
   res.send(req.params.id)
 })
 

--- a/php/laravel/routes/web.php
+++ b/php/laravel/routes/web.php
@@ -17,7 +17,7 @@ Route::get('/', function () {
 
 Route::get('/user/{id}', function ($id) {
     return $id;
-});
+})->where('id', '[0-9]+');
 
 Route::post('/user', function () {
     return '';

--- a/php/lumen/routes/web.php
+++ b/php/lumen/routes/web.php
@@ -4,7 +4,7 @@ $router->get('/', [
     'uses' => 'ApplicationController@index',
 ]);
 
-$router->get('/user/{id}', [
+$router->get('/user/{id:[0-9]+}', [
     'uses' => 'UserController@show',
 ]);
 

--- a/php/slim/public/index.php
+++ b/php/slim/public/index.php
@@ -12,7 +12,7 @@ $app->get('/', function (Request $request, Response $response): Response {
     return $response->write('');
 });
 
-$app->get('/user/{id}', function (Request $request, Response $response, array $args): Response {
+$app->get('/user/{id:[0-9]+}', function (Request $request, Response $response, array $args): Response {
     return $response->write($args['id']);
 });
 

--- a/php/symfony/src/Controller/ApplicationController.php
+++ b/php/symfony/src/Controller/ApplicationController.php
@@ -17,7 +17,7 @@ class ApplicationController extends Controller
     }
 
     /**
-     * @Route("/user/{id<\d+>}", methods={"GET"})
+     * @Route("/user/{id<[0-9]+>}", methods={"GET"})
      */
     public function user($id)
     {

--- a/php/symfony/src/Controller/ApplicationController.php
+++ b/php/symfony/src/Controller/ApplicationController.php
@@ -17,7 +17,7 @@ class ApplicationController extends Controller
     }
 
     /**
-     * @Route("/user/{id}", methods={"GET"})
+     * @Route("/user/{id<\d+>}", methods={"GET"})
      */
     public function user($id)
     {

--- a/php/zend-expressive/config/routes.php
+++ b/php/zend-expressive/config/routes.php
@@ -21,6 +21,6 @@ use Zend\Expressive\MiddlewareFactory;
  */
 return function (Application $app, MiddlewareFactory $factory, ContainerInterface $container) : void {
     $app->route('/', \App\Handler\Home::class, ['GET']);
-    $app->route('/user/{id}', \App\Handler\UserId::class, ['GET']);
+    $app->route('/user/{id:[0-9]+}', \App\Handler\UserId::class, ['GET']);
     $app->route('/user', \App\Handler\User::class, ['POST']);
 };

--- a/python/aiohttp/server.py
+++ b/python/aiohttp/server.py
@@ -13,7 +13,7 @@ async def user_info(request):
     return web.Response(text="")
 
 
-@routes.get('/user/{id:\d+}')
+@routes.get('/user/{id:[0-9]+}')
 async def user_id(request):
     return web.Response(text=request.match_info['id'])
 

--- a/python/aiohttp/server.py
+++ b/python/aiohttp/server.py
@@ -13,7 +13,7 @@ async def user_info(request):
     return web.Response(text="")
 
 
-@routes.get('/user/{id}')
+@routes.get('/user/{id:\d+}')
 async def user_id(request):
     return web.Response(text=request.match_info['id'])
 

--- a/python/cyclone/server.py
+++ b/python/cyclone/server.py
@@ -29,7 +29,7 @@ class UserHandler(cyclone.web.RequestHandler):
 if __name__ == "__main__":
     application = cyclone.web.Application([
         (r'/', MainHandler),
-        (r"/user/(\d+)", UserInfoHandler),
+        (r"/user/([0-9]+)", UserInfoHandler),
         (r"/user", UserHandler),
     ])
 

--- a/python/quart/server.py
+++ b/python/quart/server.py
@@ -10,7 +10,7 @@ async def index():
 
 @app.route('/user/<int:id>')
 async def user_info(id):
-    return id
+    return str(id)
 
 
 @app.route('/user', methods=['POST'])

--- a/python/quart/server.py
+++ b/python/quart/server.py
@@ -8,7 +8,7 @@ async def index():
     return ''
 
 
-@app.route('/user/<id>')
+@app.route('/user/<int:id>')
 async def user_info(id):
     return id
 

--- a/python/starlette/server.py
+++ b/python/starlette/server.py
@@ -10,10 +10,10 @@ async def homepage(request):
     return PlainTextResponse('')
 
 
-@app.route('/user/{user_id}')
+@app.route('/user/{user_id:int}')
 async def user(request):
     user_id = request.path_params['user_id']
-    return PlainTextResponse(user_id)
+    return PlainTextResponse(str(user_id))
 
 
 @app.route('/user', methods=['POST'])

--- a/python/tornado/server.py
+++ b/python/tornado/server.py
@@ -22,4 +22,4 @@ class UserInfoHandler(tornado.web.RequestHandler):
 
 app = tornado.web.Application(handlers=[(r'/', MainHandler),
                               (r"/user", UserHandler),
-                              (r"/user/(\d+)", UserInfoHandler)])
+                              (r"/user/([0-9]+)", UserInfoHandler)])

--- a/ruby/rails/config/routes.rb
+++ b/ruby/rails/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   get  '/'         => 'api#index'
-  get  '/user/:id' => 'api#user'
+  get  '/user/:id' => 'api#user', constraints: { id: /\d+/ }
   post '/user'     => 'api#register_user'
 end

--- a/ruby/rails/config/routes.rb
+++ b/ruby/rails/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   get  '/'         => 'api#index'
-  get  '/user/:id' => 'api#user', constraints: { id: /\d+/ }
+  get  '/user/:id' => 'api#user', constraints: { id: /[0-9]+/ }
   post '/user'     => 'api#register_user'
 end

--- a/scala/akkahttp/build.sbt
+++ b/scala/akkahttp/build.sbt
@@ -4,7 +4,7 @@ name := "AkkaHttp"
 
 version := "0.0.1"
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.12.8"
 
 mainClass in Compile := Some("Main")
 

--- a/scala/akkahttp/project/assembly.sbt
+++ b/scala/akkahttp/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")

--- a/scala/akkahttp/project/build.properties
+++ b/scala/akkahttp/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.2.8

--- a/scala/akkahttp/src/main/scala/Main.scala
+++ b/scala/akkahttp/src/main/scala/Main.scala
@@ -14,14 +14,14 @@ object Main {
       pathSingleSlash {
         complete("")
       } ~
-        path("user") {
-          post {
-            complete("")
-          }
-        } ~
-        path("user" / Remaining) { id =>
-          complete(id)
+      path("user") {
+        post {
+          complete("")
         }
+      } ~
+      path("user" / IntNumber) { id =>
+        complete(s"$id")
+      }
 
 
     Http().bindAndHandle(route, "0.0.0.0", 3000)

--- a/scala/http4s/build.sbt
+++ b/scala/http4s/build.sbt
@@ -5,7 +5,7 @@ lazy val root = (project in file("."))
     organization := "the.benchmarker",
     name := "http4s",
     version := "0.0.1-SNAPSHOT",
-    scalaVersion := "2.12.6",
+    scalaVersion := "2.12.8",
     libraryDependencies ++= Seq(
       "org.http4s"      %% "http4s-blaze-server" % Http4sVersion,
       "org.http4s"      %% "http4s-circe"        % Http4sVersion,

--- a/scala/http4s/project/assembly.sbt
+++ b/scala/http4s/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")

--- a/scala/http4s/project/build.properties
+++ b/scala/http4s/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=0.13.15
-
+sbt.version=1.2.8

--- a/scala/http4s/src/main/scala/the/benchmarker/http4s/HelloWorldService.scala
+++ b/scala/http4s/src/main/scala/the/benchmarker/http4s/HelloWorldService.scala
@@ -13,8 +13,8 @@ class HelloWorldService[F[_]: Effect] extends Http4sDsl[F] {
         Ok("")
       case POST -> Root / "user" =>
         Ok("")
-      case GET -> Root / "user" / name =>
-        Ok(name)
+      case GET -> Root / "user" / IntVar(id) =>
+        Ok(s"$id")
     }
   }
 }

--- a/spec/benchmark_spec.cr
+++ b/spec/benchmark_spec.cr
@@ -23,6 +23,13 @@ describe "get on /user/0" do
   it "should return <0>" { r.body.should eq "0" }
 end
 
+describe "get on /user/a" do
+  name = ENV["FRAMEWORK"]
+  remote_ip = get_ip(name)
+  r = HTTP::Client.get "http://#{remote_ip}:3000/user/a"
+  it "should reply with a 200 status code" { r.status_code.should eq 404 }
+end
+
 describe "post on /user" do
   name = ENV["FRAMEWORK"]
   remote_ip = get_ip(name)

--- a/spec/benchmark_spec.cr
+++ b/spec/benchmark_spec.cr
@@ -27,7 +27,7 @@ describe "get on /user/a" do
   name = ENV["FRAMEWORK"]
   remote_ip = get_ip(name)
   r = HTTP::Client.get "http://#{remote_ip}:3000/user/a"
-  it "should reply with a 200 status code" { r.status_code.should be >= 400 }
+  it "should fails" { r.status_code.should be >= 400 }
 end
 
 describe "post on /user" do

--- a/spec/benchmark_spec.cr
+++ b/spec/benchmark_spec.cr
@@ -27,7 +27,7 @@ describe "get on /user/a" do
   name = ENV["FRAMEWORK"]
   remote_ip = get_ip(name)
   r = HTTP::Client.get "http://#{remote_ip}:3000/user/a"
-  it "should reply with a 200 status code" { r.status_code.should eq 404 }
+  it "should reply with a 200 status code" { r.status_code.should be >= 400 }
 end
 
 describe "post on /user" do


### PR DESCRIPTION
Hi,

This  `PR` addresses #1148 

The purpose here is to make more uniform each implementation, to improve result accuracy

Route #2 should reply on :
- `/user/0` a **200** status code
- `/user/a` a **failure** status code (**400**, **422**, or **404**)

+ [ ] act
+ [ ] jester
+ [ ] kore
+ [ ] agoo-c
+ [ ] nickel
+ [ ] iron
+ [ ] rocket
+ [ ] actix-web
+ [ ] gotham
+ [ ] sinatra
+ [ ] rack-routing
+ [ ] cuba
+ [ ] hanami
+ [ ] agoo
+ [ ] roda
+ [ ] flame
+ [ ] rails
+ [ ] criollo
+ [ ] foxify
+ [ ] turbo_polka
+ [ ] fastify
+ [ ] hapi
+ [ ] muneem
+ [ ] restify
+ [ ] polka
+ [ ] rayo
+ [ ] koa
+ [ ] restana
+ [ ] express
+ [ ] akkahttp
+ [ ] http4s
+ [ ] evhtp
+ [ ] violetear
+ [ ] gorilla-mux
+ [ ] gin
+ [ ] beego
+ [ ] echo
+ [ ] chi
+ [ ] fasthttprouter
+ [ ] kami
+ [ ] gf
+ [ ] aspnetcore
+ [ ] plug
+ [ ] phoenix
+ [ ] perfect
+ [ ] kitura
+ [ ] vapor
+ [ ] zend-framework
+ [ ] zend-expressive
+ [ ] barak
+ [ ] slim
+ [ ] symfony
+ [ ] laravel
+ [ ] lumen
+ [ ] onyx
+ [ ] spider-gazelle
+ [ ] raze
+ [ ] amber
+ [ ] kemal
+ [ ] router.cr
+ [ ] orion
+ [ ] lucky
+ [ ] japronto
+ [ ] flask
+ [ ] falcon
+ [ ] responder
+ [ ] cyclone
+ [ ] starlette
+ [ ] hug
+ [ ] django
+ [ ] sanic
+ [ ] bottle
+ [ ] bocadillo
+ [ ] fastapi
+ [ ] tornado
+ [ ] molten
+ [ ] aiohttp
+ [ ] vibora
+ [ ] quart

Regards,
