### PR TITLE
[WIP] [Python] Enforce unicorn for ASGI frameworks

### DIFF
--- a/python/sanic/Dockerfile
+++ b/python/sanic/Dockerfile
@@ -9,4 +9,4 @@ COPY requirements.txt server.py ./
 
 EXPOSE 3000
 
-CMD gunicorn --log-level warning --bind 0.0.0.0:3000 --reuse-port --workers $(nproc) --worker-class sanic.worker.GunicornWorker server:app
+CMD python server.py $(nproc)

--- a/python/sanic/server.py
+++ b/python/sanic/server.py
@@ -1,19 +1,31 @@
 from sanic import Sanic
 from sanic.response import text
+import sys
 
 app = Sanic(log_config=None)
+WORKERS = int(sys.argv[-1])
 
 
 @app.route("/")
 async def index(request):
-    return text('')
+    return text("")
 
 
-@app.route("/user/<id:int>", methods=['GET'])
+@app.route("/user/<id:int>", methods=["GET"])
 async def user_info(request, id):
     return text(str(id))
 
 
-@app.route("/user", methods=['POST'])
+@app.route("/user", methods=["POST"])
 async def user(request):
-    return text('')
+    return text("")
+
+
+if __name__ == "__main__":
+    app.run(
+        debug=False,
+        access_log=False,
+        workers=WORKERS,
+        port=3000,
+        host="0.0.0.0",
+    )


### PR DESCRIPTION
The existing implementation here for [Sanic](https://sanicframework.org/) uses `gunicorn` instead of its own internal server. This PR updates the benchmark to run against Sanic's own server thus **greatly** improving performance.