### PR TITLE
[Nim] Update to 0.19.6 in development

### DIFF
--- a/nim/jester/Dockerfile
+++ b/nim/jester/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 
 COPY server_nim_jester.nim server_nim_jester.nimble ./
 
-RUN nimble install -y httpbeast@#v0.2.1
+RUN nimble install -y httpbeast@#v0.2.2
 RUN nimble c -d:release --threads:on -y server_nim_jester.nim
 
 CMD ./server_nim_jester

--- a/nim/jester/Dockerfile
+++ b/nim/jester/Dockerfile
@@ -1,4 +1,4 @@
-FROM nimlang/nim:0.19.4
+FROM nimlang/nim:0.19.6
 
 WORKDIR /usr/src/app
 

--- a/nim/jester/server_nim_jester.nimble
+++ b/nim/jester/server_nim_jester.nimble
@@ -8,4 +8,4 @@ license       = "MIT"
 # Dependencies
 
 requires "nim >= 0.19.0"
-requires "jester#v0.4.1"
+requires "jester#v0.4.2"


### PR DESCRIPTION
Hi,

This `PR` update to `nim` `0.19.6`.

It also update `jester` to the **latest** version.

Regards,