### PR TITLE
[PHP] Add swoole variant

### DIFF
--- a/php/symfony/Dockerfile
+++ b/php/symfony/Dockerfile
@@ -1,9 +1,4 @@
-FROM php:7.3.5-fpm
-
-RUN apt-get -qy update
-RUN apt-get -y install git nginx zlib1g-dev libzip-dev
-RUN docker-php-ext-install zip opcache
-
+FROM zaherg/php-swoole:7.3
 
 WORKDIR /usr/src/app
 
@@ -13,46 +8,15 @@ COPY config config
 COPY public public
 COPY bin bin
 
-RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+USER root
 RUN composer install --no-dev --prefer-dist --classmap-authoritative
 
-RUN sed -i 's/\;prefix.*/prefix = \/usr\/src\/app\/public/g' /usr/local/etc/php-fpm.d/www.conf
-RUN sed -i 's/\(listen =\).*/\1 \/var\/run\/php-fpm.sock/g' /usr/local/etc/php-fpm.d/www.conf
-RUN sed -i 's/\;\(listen\.owner.*\).*/\1/g' /usr/local/etc/php-fpm.d/www.conf
-RUN sed -i 's/\;\(listen\.group.*\).*/\1/g' /usr/local/etc/php-fpm.d/www.conf
-RUN sed -i 's/\;\(listen\.mode.*\).*/\1/g' /usr/local/etc/php-fpm.d/www.conf
-
-RUN rm -fr /etc/nginx/sites-enabled/default
-RUN rm -fr /usr/local/etc/php-fpm.d/zz-docker.conf
-
 ENV APP_ENV prod
-
 RUN mkdir -p var/log && chown www-data var/log
 RUN mkdir -p var/cache && chown www-data var/cache
 RUN php bin/console cache:warmup
 
-RUN echo 'server {\n\
-    root /usr/src/app/public;\n\
-    listen 0.0.0.0:3000;\n\
-    location / {\n\
-        fastcgi_pass unix:/var/run/php-fpm.sock;\n\
-        fastcgi_param   SCRIPT_FILENAME         $document_root/index.php;\n\
-        include fastcgi_params;\n\
-    }\n\
-}\n'\
->> /etc/nginx/conf.d/www.conf
-
-RUN echo 'opcache.enable=1\n\
-opcache.memory_consumption=512\n\
-opcache.interned_strings_buffer=64\n\
-opcache.max_accelerated_files=32531\n\
-opcache.validate_timestamps=0\n\
-opcache.save_comments=1\n\
-opcache.fast_shutdown=0\n'\
->> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
-
-RUN echo "daemon off;" >> /etc/nginx/nginx.conf
-
 EXPOSE 3000
 
-CMD /usr/local/sbin/php-fpm --daemonize; service nginx start
+USER www-data
+CMD bin/console swoole:server:run --host=0.0.0.0 --port=3000

--- a/php/symfony/composer.json
+++ b/php/symfony/composer.json
@@ -1,8 +1,11 @@
 {
     "require": {
+        "php": "~7.3",
+        "ext-swoole": "~4",
         "symfony/yaml": "4.2.8",
         "symfony/console": "4.2.8",
-        "sensio/framework-extra-bundle": "5.3.1"
+        "sensio/framework-extra-bundle": "5.3.1",
+        "k911/swoole-bundle": "0.5.2"
     },
     "config": {
         "preferred-install": {

--- a/php/symfony/config/bundles.php
+++ b/php/symfony/config/bundles.php
@@ -2,4 +2,5 @@
 
 return [
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    K911\Swoole\Bridge\Symfony\Bundle\SwooleBundle::class => ['all' => true],
 ];


### PR DESCRIPTION
Hi,

I've found on https://github.com/symfony/symfony/issues/28054 that `symfony ` could run on `swoole`.

I have some interesting results :

|   | Average | 50th percentile | 90th percentile | 99th percentile | 99.9th percentile | Standard deviation |Requests / s | Throughput |
|--------------------------------|----------------:|----------------:|----------------:|----------------:|----------------:|----------------:|----------------:|---------:|
| swoole (4.3)  | 55.02 ms | 53.89 ms | 83.27 ms | 119.79 ms | 230.44 ms | 22821.33 | 17858.00 | 54.15 MB | 
| php-fpm (7.3) | 155.11 ms | 0.34 ms | 252.81 ms | 3401.70 ms | 6805.22 ms | 586349.67 |  63795.33 | 316.16 MB |

Computed on a [droplet](https://www.digitalocean.com/products/droplets) `8 CPU x 32 G` through a **docker engine**

/cc @nicolas-grekas @doanguyen @stdex @robopuff 