### PR TITLE
[Crystal] Temporarily fix multi-processing mode of Amber server

### DIFF
--- a/crystal/amber/config/application.cr
+++ b/crystal/amber/config/application.cr
@@ -75,7 +75,7 @@ Amber::Server.configure do |settings|
   # spinning an instance for each number of process specified here.
   # Rule of thumb, always leave at least 1 core available for system processes/resources.
   #
-  settings.process_count = System.cpu_count.to_i32
+  #settings.process_count = System.cpu_count.to_i32
   #
   #
   # PORT: This is the port that you're application will run on. Examples would be (80, 443, 3000, 8080)

--- a/crystal/amber/src/amber.cr
+++ b/crystal/amber/src/amber.cr
@@ -1,4 +1,11 @@
 require "../config/*"
 
 Amber.env = "production"
-Amber::Server.start
+
+System.cpu_count.times do |i|
+  Process.fork do
+    Amber::Server.start
+  end
+end
+
+sleep


### PR DESCRIPTION
The priority of the settings in `config/application.cr` does not seem to
be higher than the settings in `config/environments/*.yml`.
And the cluster mode of Amber is buggy at the moment. If the setting of
`process_count: 1` in `config/environments/*.yml` is changed to
`process_count: 4`, then the result is 8 sub-processes are forked.
The simplest workaroud at the moment is to fork `System.cpu_count`
sub-processes in `src/amber.cr`.
