### PR TITLE
[Crystal] Disable logging for athena benchmarking

### DIFF
--- a/crystal/athena/Dockerfile
+++ b/crystal/athena/Dockerfile
@@ -8,4 +8,6 @@ COPY athena.yml ./
 
 RUN shards build --release --no-debug
 
+ENV ATHENA_ENV test
+
 CMD bin/server

--- a/crystal/athena/Dockerfile
+++ b/crystal/athena/Dockerfile
@@ -6,7 +6,7 @@ COPY src src
 COPY shard.yml ./
 COPY athena.yml ./
 
-RUN shards build --release --no-debug
+RUN shards build --production --no-debug
 
 ENV ATHENA_ENV test
 

--- a/crystal/athena/athena.yml
+++ b/crystal/athena/athena.yml
@@ -1,1 +1,20 @@
 # Config file for Athena.
+---
+environments:
+  development: &development
+    routing:
+      cors:
+        enabled: false
+        strategy: blacklist
+        defaults: &defaults
+          allow_origin: https://yourdomain.com
+          expose_headers: []
+          max_age: 0
+          allow_credentials: false
+          allow_methods: []
+          allow_headers: []
+        groups: {}
+  test: &test
+    <<: *development
+  production: &production
+    <<: *development

--- a/crystal/athena/config.yaml
+++ b/crystal/athena/config.yaml
@@ -1,4 +1,3 @@
 framework:
   github: blacksmoke16/athena
-  version: 0.6
-  
+  version: 0.7


### PR DESCRIPTION
Sets the `ATHENA_ENV` to `test` to disable logging when running the benchmark.  This should regain some performance as logs would not be written to `STDOUT` or the `development.log` file.