### PR TITLE
[Rust] Update gotham to 0.4

### DIFF
--- a/rust/gotham/Cargo.toml
+++ b/rust/gotham/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 authors = ["Isaac Whitfield <iw@whitfin.io>"]
 
 [dependencies]
-gotham = "0.3"
-gotham_derive = "0.3"
-hyper = "0.12"
-serde = "1.0"
-serde_derive = "1.0"
+gotham = "0.4"
+gotham_derive = "*"
+hyper = "*"
+serde = "*"
+serde_derive = "*"
 
 [profile.release]
 codegen-units = 1

--- a/rust/gotham/config.yaml
+++ b/rust/gotham/config.yaml
@@ -1,4 +1,4 @@
 framework:
   website: gotham.rs
-  version: 0.3
+  version: 0.4
   


### PR DESCRIPTION
Hi,

This  `PR` update `gotham` to **0.4**

I've used an `*` for `hyper` version, since `gotham` himself specify its version to use (I prefer to avoid double specifications)

Regards,