### PR TITLE
Wrong path for dependabot config file / node

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -78,67 +78,67 @@ update_configs:
   - docker
 - package_manager: javascript
   update_schedule: live
-  directory: javascript/hapi
+  directory: node/hapi
   default_labels:
   - language:javascript
 - package_manager: javascript
   update_schedule: live
-  directory: javascript/fastify
+  directory: node/fastify
   default_labels:
   - language:javascript
 - package_manager: javascript
   update_schedule: live
-  directory: javascript/0http
+  directory: node/0http
   default_labels:
   - language:javascript
 - package_manager: javascript
   update_schedule: live
-  directory: javascript/muneem
+  directory: node/muneem
   default_labels:
   - language:javascript
 - package_manager: javascript
   update_schedule: live
-  directory: javascript/polkadot
+  directory: node/polkadot
   default_labels:
   - language:javascript
 - package_manager: javascript
   update_schedule: live
-  directory: javascript/rayo
+  directory: node/rayo
   default_labels:
   - language:javascript
 - package_manager: javascript
   update_schedule: live
-  directory: javascript/koa
+  directory: node/koa
   default_labels:
   - language:javascript
 - package_manager: javascript
   update_schedule: live
-  directory: javascript/express
+  directory: node/express
   default_labels:
   - language:javascript
 - package_manager: javascript
   update_schedule: live
-  directory: javascript/foxify
+  directory: node/foxify
   default_labels:
   - language:javascript
 - package_manager: javascript
   update_schedule: live
-  directory: javascript/restify
+  directory: node/restify
   default_labels:
   - language:javascript
 - package_manager: javascript
   update_schedule: live
-  directory: javascript/turbo_polka
+  directory: node/turbo_polka
   default_labels:
   - language:javascript
 - package_manager: javascript
   update_schedule: live
-  directory: javascript/restana
+  directory: node/restana
   default_labels:
   - language:javascript
 - package_manager: javascript
   update_schedule: live
-  directory: javascript/polka
+  directory: node/polka
   default_labels:
   - language:javascript
 - package_manager: docker

--- a/tools/src/make.cr
+++ b/tools/src/make.cr
@@ -228,7 +228,11 @@ class App < Admiral::Command
                     yaml.scalar "update_schedule"
                     yaml.scalar mapping["languages"][language]["update_schedule"]
                     yaml.scalar "directory"
-                    yaml.scalar "#{language}/#{tool}"
+                    if language == "javascript"
+                      yaml.scalar "node/#{tool}"
+                    else
+                      yaml.scalar "#{language}/#{tool}"
+                    end
                     yaml.scalar "default_labels"
                     yaml.sequence do
                       yaml.scalar "language:#{language}"


### PR DESCRIPTION
Hi,

This `PR` fix a misconfiguration for **dependabot** (on `JavaScript`).

Closes :
+ #1544 
+ #1545 
+ #1546 
+ #1547 
+ #1548 
+ #1549 
+ #1550 
+ #1551 
+ #1552 
+ #1553 
+ #1554 
+ #1555 
+ #1556 

Regards,
