### PR TITLE
[Go] Remove goproxy env

### DIFF
--- a/go/air/Dockerfile
+++ b/go/air/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/atreugo/Dockerfile
+++ b/go/atreugo/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/beego/Dockerfile
+++ b/go/beego/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/chi/Dockerfile
+++ b/go/chi/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/echo/Dockerfile
+++ b/go/echo/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/fasthttprouter/Dockerfile
+++ b/go/fasthttprouter/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/gf/Dockerfile
+++ b/go/gf/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/gin/Dockerfile
+++ b/go/gin/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/gorilla-mux/Dockerfile
+++ b/go/gorilla-mux/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/goroute/Dockerfile
+++ b/go/goroute/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/gorouter-fasthttp/Dockerfile
+++ b/go/gorouter-fasthttp/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/gorouter/Dockerfile
+++ b/go/gorouter/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/gramework/Dockerfile
+++ b/go/gramework/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/kami/Dockerfile
+++ b/go/kami/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/rte/Dockerfile
+++ b/go/rte/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./

--- a/go/violetear/Dockerfile
+++ b/go/violetear/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1.13 AS buildenv
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
-ENV GOPROXY=https://proxy.golang.org
 
 WORKDIR /go/src/app
 ADD main.go go.mod ./


### PR DESCRIPTION
The default value of `GOPROXY` is `https://proxy.golang.org,direct` in `go1.13` version now so we don't need to set `GOPROXY` value.