### PR TITLE
[Ruby] Use a single thread for the server

### DIFF
--- a/ruby/plezi/Dockerfile
+++ b/ruby/plezi/Dockerfile
@@ -6,4 +6,4 @@ COPY Gemfile config.ru ./
 
 RUN bundle install
 
-CMD bundle exec iodine -w $(nproc)  -p 3000 -t 16
+CMD bundle exec iodine -w $(nproc) -p 3000 -t 1


### PR DESCRIPTION
When using `nproc` X 16 threads, there are 16 times the number of concurrent threads then there are processor cores.

This slows down the machine due to excessive lock contention and context switches. It only makes sense if most of the time the threads are "sleeping" or waiting on external IO (database requests).

For this simple plaintext test, a single thread would be better.

In fact, if I were to leave `nproc` behind, I would probably leave one CPU core available for OS tasks (`-w -1` would default to that state)... but maybe that could be tested across the board for everyone (by editing `nproc`).