### PR TITLE
Enable multi manager manifests

### DIFF
--- a/.dependabot/mapping.yaml
+++ b/.dependabot/mapping.yaml
@@ -1,37 +1,36 @@
 languages:
   ruby:
-    label: ruby:bundler
-    update_schedule: "live"
-    manifest: Gemfile
+    Gemfile:
+      label: ruby:bundler
+      update_schedule: live
   javascript:
-    label: javascript
-    update_schedule: "live"
-    manifest: package.json
+    package.json:
+      label: javascript
+      update_schedule: live
   python:
-    label: python
-    update_schedule: "live"
-    manifest: requirements.txt
+    requirements.txt:
+      label: python
+      update_schedule: live
   php:
-    label: php:composer
-    update_schedule: "live"
-    manifest: composer.json
+    composer.json:
+      label: php:composer
+      update_schedule: live
   elixir:
-    label: elixir:hex
-    update_schedule: "live"
-    manifest: mix.exs
+    mix.exs:
+      label: elixir:hex
+      update_schedule: live
   rust:
-    label: rust:cargo
-    update_schedule: "live"
-    manifest: Cargo.toml
+    Cargo.toml:
+      label: rust:cargo
+      update_schedule: live
   java:
-    label: java:maven
-    update_schedule: "daily"
-    manifest: pom.xml
+    pom.xml:
+      label: java:maven
+      update_schedule: daily
+    build.gradle:
+      label: java:gradle
+      update_schedule: daily
   go:
-    label: go:modules
-    update_schedule: "daily"
-    manifest: go.mod
-docker:
-  update_schedule: "daily"
-  default_labels:
-    - docker
+    go.mod:
+      label: go:modules
+      update_schedule: daily

--- a/tools/src/make.cr
+++ b/tools/src/make.cr
@@ -210,17 +210,23 @@ class App < Admiral::Command
                 # Exist if not exist for @dependabot
                 next unless mapping["languages"].as_h[language]?
 
-                # Exist if no manifest file
-                manifest = mapping["languages"][language]["manifest"].to_s
-                next unless File.exists?("#{language}/#{tool}/#{manifest}")
-
                 language = "javascript" if language == "node" # FIXME
 
+                # Exist if no manifest file
+                manifest = String.new
+                mapping["languages"][language].as_h.keys.each do |key|
+                file = key.to_s
+                 if File.exists?("#{language}/#{tool}/#{file}")
+                   manifest = file
+                  end
+                end
+                next if manifest.chars.size == 0
+                
                 yaml.mapping do
                   yaml.scalar "package_manager"
-                  yaml.scalar mapping["languages"][language]["label"]
+                  yaml.scalar mapping["languages"][language][manifest]["label"]
                   yaml.scalar "update_schedule"
-                  yaml.scalar mapping["languages"][language]["update_schedule"]
+                  yaml.scalar mapping["languages"][language][manifest]["update_schedule"]
                   yaml.scalar "directory"
                   if language == "javascript"
                     yaml.scalar "node/#{tool}"
@@ -233,6 +239,7 @@ class App < Admiral::Command
                   end
                 end
               end
+
               language = "node" if language == "javascript" # FIXME
             end
           end


### PR DESCRIPTION
Hi,

Several build tool could be used for a single language, for example in `java`, we can use :
+ `maven`
+ `gradle`
+ ...

This `PR` closes #1962, it is about enabling `gradle` for `java` based **frameworks.

Regards,