### PR TITLE
add nanoexpress (+pro) to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,8 @@ env:
     - FRAMEWORK=suave
     - FRAMEWORK=restana
     - FRAMEWORK=express
+    - FRAMEWORK=nanoexpress
+    - FRAMEWORK=nanoexpress-pro
     - FRAMEWORK=muneem
     - FRAMEWORK=iotjs-express
     - FRAMEWORK=polka


### PR DESCRIPTION
Before submitting your PR, please review the following checklist :

## If you are adding a framework

+ [ ] A `Dockerfile` exists, or can be built ?
+ [x] I've updated `CI` config file (and **commited** `.travis.yml`)
~~~sh
bin/make ci_config
~~~
+ [ ] I've updated `.dependabot` config file  (and **commited** `.dependabot/config.yml`)
~~~sh
bin/make deps_config
~~~
+ [ ] All tests passes ?
~~~
export FRAMEWORK=<MY_FRAMEWORK>
shards install
shards build --release
bin/make config
bin/neph ${FRAMEWORK}
crystal spec
~~~

## Note

Hi, @waghanza. In previous PR i forgot adding nanoexpress and nanoexpress Pro to Travis CI and i think because of this results aren't changed. This PR should fix this