### PR TITLE
[Nim] Update containers to 1.04

### DIFF
--- a/nim/Dockerfile
+++ b/nim/Dockerfile
@@ -1,4 +1,4 @@
-FROM nimlang/nim:1.0.2-alpine
+FROM nimlang/nim:1.0.4-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Hi,

This `PR` update `nim` to `1.0.4`.

@dom96 @moigagoo Actually **nimlang/nim:1.0** in `docker`

I think it could be good, to have a **1.0** tag that link to the last patched version (`1.0.2`, `1.0.4` ...) in this **major**

Regards,