### PR TITLE
[Crystal] Update spider-gazelle to 2.2

### DIFF
--- a/crystal/spider-gazelle/config.yaml
+++ b/crystal/spider-gazelle/config.yaml
@@ -1,4 +1,4 @@
 framework:
   website: spider-gazelle.net
-  version: 2.1
+  version: 2.2
   

--- a/crystal/spider-gazelle/shard.yml
+++ b/crystal/spider-gazelle/shard.yml
@@ -6,7 +6,7 @@ licence: MIT
 dependencies:
   action-controller:
     github: spider-gazelle/action-controller
-    version: ~> 2.1
+    version: ~> 2.2
 
 targets:
   server:


### PR DESCRIPTION
Hi @stakach,

This `PR` updates `spider-gazelle` to **2.2**

As you know we only show `requests/seconds`.

The gap between `2.1` and `2.2` is from **148 455** to **145 473** and show a decrease, but no very significant

Regards,