### PR TITLE
[Crystal] Update orion to 2.1

### DIFF
--- a/crystal/orion/config.yaml
+++ b/crystal/orion/config.yaml
@@ -1,4 +1,4 @@
 framework:
   github: obsidian/orion
-  version: 1.7
+  version: 2.1
   

--- a/crystal/orion/shard.yml
+++ b/crystal/orion/shard.yml
@@ -11,7 +11,7 @@ targets:
 dependencies:
   orion:
     github: obsidian/orion
-    version: ~> 1.7.0
+    version: ~> 2.1
 
 crystal: 0.29.0
 


### PR DESCRIPTION
Hi @jwaldrip,

This `PR` update `orion` from `1.7` to `2.1`

I do not notice any change in `req/s`, from `124 639` to `124 292`

Do you maintain any changelog ?

Regards,