### PR TITLE
turn off sanic debugging and access logging

### DIFF
--- a/python/sanic/server.py
+++ b/python/sanic/server.py
@@ -1,7 +1,7 @@
 from sanic import Sanic
 from sanic.response import text
 
-app = Sanic(log_config=None)
+app = Sanic(debug=False, access_log=False)
 
 
 @app.route("/")


### PR DESCRIPTION
this will turn off sanics access and debug logs, as per their documentation, which is supposed to be done in a production environment