### PR TITLE
fix go/fiber's broken link

### DIFF
--- a/go/fiber/config.yaml
+++ b/go/fiber/config.yaml
@@ -1,3 +1,3 @@
 framework:
-  website: gofiber.github.io/fiber
+  website: fiber.wiki
   version: 1.4


### PR DESCRIPTION
It seems [gofiber.github.io/fiber](https://gofiber.github.io/fiber) has been changed to [fiber.wiki](https://fiber.wiki)