### PR TITLE
[Crystal] Upgrade to 0.33

### DIFF
--- a/crystal/Dockerfile
+++ b/crystal/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.32.1-alpine
+FROM crystallang/crystal:0.33.0-alpine
 
 WORKDIR /usr/src/app
 

--- a/crystal/config.yaml
+++ b/crystal/config.yaml
@@ -1,3 +1,3 @@
 provider:
   default:
-    language: 0.32
+    language: 0.33

--- a/tools/src/db.cr
+++ b/tools/src/db.cr
@@ -94,7 +94,7 @@ class App < Admiral::Command
 
       path = File.expand_path("../../../README.mustache.md", __FILE__)
       template = Crustache.parse(File.read(path))
-      STDOUT.print Crustache.render template, {"results" => lines, "date": Time.now.to_s("%Y-%m-%d")}
+      STDOUT.print Crustache.render template, {"results" => lines, "date": Time.local.to_s("%Y-%m-%d")}
     end
   end
 


### PR DESCRIPTION
Hi,

This `PR` update `crystal` to  `0.33` 
@see https://crystal-lang.org/2020/02/14/crystal-0.33.0-released.html

Regards,

---------------

Closes #2277, #2278