### PR TITLE
Ruby 2.7

### DIFF
--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine
+FROM ruby:2.7-alpine
 
 WORKDIR /usr/src/app
 

--- a/ruby/config.yaml
+++ b/ruby/config.yaml
@@ -1,3 +1,3 @@
 provider:
   default:
-    language: 2.6
+    language: 2.7


### PR DESCRIPTION
Hello, I want to add the newer addition to the Hanami (Ruby) family: `hanami-api`. But that is only compatible with Ruby 2.7+.

This PR upgrades the Ruby version for all the Ruby benchmarks. In an upcoming PR, I'll add the new framework.

I hope to help. Thanks!