### PR TITLE
chore(nanoexpress): update link

### DIFF
--- a/javascript/nanoexpress/config.yaml
+++ b/javascript/nanoexpress/config.yaml
@@ -1,5 +1,5 @@
 framework:
-  website: nanoexpress.js.org
+  github: nanoexpress/nanoexpress
   version: 1.1
 
 build_deps:

--- a/javascript/nanoexpress/package.json
+++ b/javascript/nanoexpress/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "nanoexpress": "~1.1.6"
+    "nanoexpress": "~1.1.16"
   }
 }


### PR DESCRIPTION
Thanks to nanoexpress sponsors, we now can add [nanoexpress Pro](https://github.com/nanoexpress/pro) here too.

Within few month v2.0 will be released (currently available as [slim](https://github.com/nanoexpress/pro-slim) and unfinished) which has better performance, stability and less resource usage