### PR TITLE
[Crystal] Update amber to 0.34

### DIFF
--- a/crystal/amber/config.yaml
+++ b/crystal/amber/config.yaml
@@ -1,6 +1,6 @@
 framework:
   website: amberframework.org
-  version: 0.33
+  version: 0.34
   
 files:
   - config

--- a/crystal/amber/shard.yml
+++ b/crystal/amber/shard.yml
@@ -14,4 +14,4 @@ targets:
 dependencies:
   amber:
     github: amberframework/amber
-    version: ~> 0.33.0
+    version: ~> 0.34.0


### PR DESCRIPTION
Hi,

This `PR` updates [amber](https://amberframework.org) to **0.34**.

Please notice that this version is compatible with `crystal` `>= 0.34`

Regards,