### PR TITLE
Avoid unnecessary builds

### DIFF
--- a/.ci/has_to_run.sh
+++ b/.ci/has_to_run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+# Always runs if master
+if [ "${TRAVIS_BRANCH}" == "master" ] ; then
+  exit 0
+fi
+
+# List of updated files
+git diff master.. --name-only  > /tmp/files.txt
+
+FWK=`echo ${FRAMEWORK} | awk -F '.' '{print $1}'`
+LNG=`echo ${FRAMEWORK} | awk -F '.' '{print $2}'`
+
+grep "${FWK}" /tmp/files.txt
+
+if [ $? -eq 0 ]; then
+  echo "${FWK} has been updated, running CI"
+  exit 0
+fi
+
+grep "${LNG}" /tmp/files.txt
+
+if [ $? -eq 0 ]; then
+  echo "${LNG} has been updated, running CI"
+  exit 0
+fi
+
+echo "No modification detected, exiting ..."
+exit 1

--- a/.ci/template.mustache
+++ b/.ci/template.mustache
@@ -1,3 +1,6 @@
+# Exit build if no modification found
+before_install: bash .ci/has_to_run.sh || travis_terminate 0
+
 # Use latest ubuntu LTS (18.04)
 dist: bionic
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Exit build if no modification found
+before_install: bash .ci/has_to_run.sh || travis_terminate 0
+
 # Use latest ubuntu LTS (18.04)
 dist: bionic
 


### PR DESCRIPTION
Hi,

This `PR` use _travis_terminate_ built-in function to exists unnecessary builds.

Builds are considered necessary, if :
+ from **master**
+ correspond to a modified **framework**
+ correspond to a modified **language**

Regards,