### PR TITLE
[F#] Upgrade containers to 4.7

### DIFF
--- a/.ci/has_to_run.sh
+++ b/.ci/has_to_run.sh
@@ -46,8 +46,8 @@ fi
 LNG=`echo ${FRAMEWORK} | awk -F '.' '{print $1}'`
 FWK=`echo ${FRAMEWORK} | awk -F '.' '{print $2}'`
 
-grep "${FWK}" /tmp/list.txt && exit 0
-grep "${LNG}" /tmp/list.txt && exit 0
+grep "^${LNG}/" /tmp/list.txt && exit 0
+grep "^${LNG}/${FWK}/" /tmp/list.txt && exit 0
 
 echo "No modification, exiting ..."
 exit 1

--- a/fsharp/Dockerfile
+++ b/fsharp/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine
+FROM fsharp:10.7
 
 WORKDIR /usr/src/app
 

--- a/fsharp/Dockerfile
+++ b/fsharp/Dockerfile
@@ -1,4 +1,4 @@
-FROM fsharp:10.7
+FROM fsharp:10.7-netcore
 
 WORKDIR /usr/src/app
 

--- a/fsharp/config.yaml
+++ b/fsharp/config.yaml
@@ -1,3 +1,3 @@
 provider:
   default:
-    language: 10.2
+    language: 4.7

--- a/fsharp/config.yaml
+++ b/fsharp/config.yaml
@@ -1,3 +1,3 @@
 provider:
   default:
-    language: 4.7
+    language: 10.2


### PR DESCRIPTION
Hi @ademar,

I'm right to consider that running in a container based on `fsharp:10.7-netcore` use version `4.7` of fsharp ?

Regards,

------------
Closes #2473 