### PR TITLE
[Crystal] Update spider-gazelle to 2.4

### DIFF
--- a/crystal/spider-gazelle/config.yaml
+++ b/crystal/spider-gazelle/config.yaml
@@ -1,4 +1,3 @@
 framework:
   website: spider-gazelle.net
-  version: 2.3
-  
+  version: 2.4

--- a/crystal/spider-gazelle/shard.yml
+++ b/crystal/spider-gazelle/shard.yml
@@ -6,7 +6,7 @@ licence: MIT
 dependencies:
   action-controller:
     github: spider-gazelle/action-controller
-    version: ~> 2.3
+    version: ~> 2.4.0
 
 targets:
   server:


### PR DESCRIPTION
Hi,

This `PR` updates `spider-gazelle` to **2.4**

@stakach Does `spider-gazelle` version is driven by https://github.com/spider-gazelle/action-controller ?

Regards,