### PR TITLE
[Elixir] Use X.Y.Z version

### DIFF
--- a/elixir/cowboy/mix.exs
+++ b/elixir/cowboy/mix.exs
@@ -29,7 +29,7 @@ defmodule Server.MixProject do
 
   defp deps do
     [
-      {:cowboy, "~> 2.7"}
+      {:cowboy, "~> 2.7.0"}
     ]
   end
 end

--- a/elixir/cowboy_stream/mix.exs
+++ b/elixir/cowboy_stream/mix.exs
@@ -29,7 +29,7 @@ defmodule Server.MixProject do
 
   defp deps do
     [
-      {:cowboy, "~> 2.7"}
+      {:cowboy, "~> 2.7.0"}
     ]
   end
 end

--- a/elixir/phoenix/mix.exs
+++ b/elixir/phoenix/mix.exs
@@ -30,8 +30,8 @@ defmodule Server.MixProject do
 
   defp deps do
     [
-      {:phoenix, "~> 1.4"},
-      {:jason, "~> 1.0"},
+      {:phoenix, "~> 1.4.0"},
+      {:jason, "~> 1.2"},
       {:plug_cowboy, "~> 2.0"}
     ]
   end

--- a/elixir/plug/config.yaml
+++ b/elixir/plug/config.yaml
@@ -1,3 +1,3 @@
 framework:
   website: hexdocs.pm/plug
-  version: 1.8
+  version: "1.10"

--- a/elixir/plug/mix.exs
+++ b/elixir/plug/mix.exs
@@ -29,6 +29,7 @@ defmodule Server.MixProject do
 
   defp deps do
     [
+      {:plug, "~> 1.10.0"},
       {:plug_cowboy, "~> 2.0"}
     ]
   end


### PR DESCRIPTION
Hi,

According to https://hexdocs.pm/elixir/Version.html, it is better to stick to `X.Y.Z` format to ensure parity of version displayed, and version used.

@esse Could you specify somethink in `mix.exs` to use *any* version of `plug_cowboy` in https://github.com/the-benchmarker/web-frameworks/blob/63422950ceba428840fca673fa93a9d73d90426a/elixir/plug/mix.exs#L32

/cc @essen @OvermindDL1 feel free to check `elixir` code `here` :heart: 

Regards,