### PR TITLE
Fix/refine commands param

### DIFF
--- a/tools/src/client.cr
+++ b/tools/src/client.cr
@@ -27,6 +27,7 @@ class Client < Admiral::Command
   define_flag framework : String, description: "Framework used", required: true, long: "framework", short: "f"
   define_flag concurrencies : Array(Int32), description: "Concurrency level", required: true, long: "concurrency", short: "c"
   define_flag routes : Array(String), long: "routes", short: "r", default: ["GET:/"]
+  define_flag host : String, description: "Host and port instead ip.txt"
 
   def run
     db = DB.open(ENV["DATABASE_URL"])
@@ -40,22 +41,21 @@ class Client < Admiral::Command
     framework_id = row.read(Int)
 
     sleep 25 # due to external program usage
-
-    address = File.read("ip.txt").strip
+    address = flags.host ? flags.host : File.read("ip.txt").strip + ":3000"
 
     # Run a 5-second primer at 8 client-concurrency to verify that the server is in fact running. These results are not captured.
 
-    process = Process.new("wrk", ["-H", "Connection: keep-alive", "-d", "5s", "-c", "8", "--timeout", "8", "-t", flags.threads.to_s, "http://#{address}:3000"])
+    process = Process.new("wrk", ["-H", "Connection: keep-alive", "-d", "5s", "-c", "8", "--timeout", "8", "-t", flags.threads.to_s, "http://#{address}"])
     process.wait
 
     # Run a 15-second warmup at 256 client-concurrency to allow lazy-initialization to execute and just-in-time compilation to run. These results are not captured.
 
-    process = Process.new("wrk", ["-H", "Connection: keep-alive", "-d", "#{flags.duration}s", "-c", "256", "--timeout", "8", "-t", flags.threads.to_s, "http://#{address}:3000"])
+    process = Process.new("wrk", ["-H", "Connection: keep-alive", "-d", "#{flags.duration}s", "-c", "256", "--timeout", "8", "-t", flags.threads.to_s, "http://#{address}"])
     process.wait
 
     flags.routes.each do |route|
       method, uri = route.split(":")
-      url = "http://#{address}:3000#{uri}"
+      url = "http://#{address}#{uri}"
 
       flags.concurrencies.each do |concurrency|
         row = db.query("INSERT INTO concurrencies (level) VALUES ($1) ON CONFLICT (level) DO UPDATE SET level = $1 RETURNING id", concurrency)

--- a/tools/src/client.cr
+++ b/tools/src/client.cr
@@ -20,6 +20,7 @@ def insert(framework_id, metric, value, concurrency_level_id)
 end
 
 class Client < Admiral::Command
+  define_help
   define_flag threads : Int32, description: "# of threads", default: 8, long: "threads", short: "t"
   define_flag duration : Int32, description: "Time to test, in seconds", default: 15, long: "duration", short: "d"
   define_flag language : String, description: "Language used", required: true, long: "language", short: "l"

--- a/tools/src/db.cr
+++ b/tools/src/db.cr
@@ -107,11 +107,12 @@ class App < Admiral::Command
     end
   end
 
+  define_help
   register_sub_command to_readme : ReadmeWriter, description "Update readme with results"
   register_sub_command clear : ClearResults, description "Clears the data from past runs"
 
   def run
-    puts "help"
+    puts help
   end
 end
 

--- a/tools/src/make.cr
+++ b/tools/src/make.cr
@@ -16,6 +16,7 @@ end
 
 class App < Admiral::Command
   class Config < Admiral::Command
+    define_help
     define_flag without_sieger : Bool, description: "run sieger", default: false, long: "without-sieger"
     define_flag docker_options : String, description: "extra argument to docker cli", default: "", long: "docker-options"
     define_flag keep : Bool, description: "keep container after build (default : false)", default: false, long: "keep"
@@ -333,12 +334,13 @@ class App < Admiral::Command
     end
   end
 
+  define_help
   register_sub_command config : Config, description "Create framework list"
   register_sub_command ci_config : TravisConfig, description "Create configuration file for CI"
   register_sub_command deps_config : DependabotConfig, description "Create configuration file for deps update bot"
 
   def run
-    puts "help"
+    puts help
   end
 end
 

--- a/tools/src/make.cr
+++ b/tools/src/make.cr
@@ -20,6 +20,7 @@ class App < Admiral::Command
     define_flag without_sieger : Bool, description: "run sieger", default: false, long: "without-sieger"
     define_flag docker_options : String, description: "extra argument to docker cli", default: "", long: "docker-options"
     define_flag keep : Bool, description: "keep container after build (default : false)", default: false, long: "keep"
+    define_flag local_port : UInt16, description: "bind docker port 3000 to localhost port (docker desktop)", default: 0_u16, long: "local-port"
 
     def run
       frameworks = {} of String => Array(String)
@@ -219,6 +220,9 @@ class App < Admiral::Command
                 params["files"] = files
               end
 
+              container_expose = flags.local_port != 0 ? "-p 127.0.0.1:#{flags.local_port}:3000" : ""
+              container_host = flags.local_port != 0 ? "--host 127.0.0.1:#{flags.local_port}" : ""
+
               File.write("#{language}/#{tool}/Dockerfile", Crustache.render(dockerfile, params))
 
               yaml.scalar "#{language}.#{tool}"
@@ -230,13 +234,13 @@ class App < Admiral::Command
                   yaml.scalar "docker build -t #{language}.#{tool} . #{flags.docker_options}"
 
                   # Run container, and store IP
-                  yaml.scalar "docker run -td #{language}.#{tool} | xargs -i docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' {} > ip.txt"
+                  yaml.scalar "docker run #{container_expose} -td #{language}.#{tool} | xargs -i docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' {} > ip.txt"
 
                   # Launch sieging
                   unless flags.without_sieger
                     factor = System.cpu_count**2
                     concurrencies = [] of Int32
-                    command = "../../bin/client --language #{language} --framework #{tool} -r GET:/ -r GET:/user/0 -r POST:/user"
+                    command = "../../bin/client #{container_host} --language #{language} --framework #{tool} -r GET:/ -r GET:/user/0 -r POST:/user"
                     [1, 4, 8, 16, 32].each do |i|
                       command += " -c #{factor*i} "
                     end


### PR DESCRIPTION
Hi there,

1. Adding `define_help` to be able to show help when no argument or `--help` invokes.
2. Add flags for make command to adding docker port binding to local when develop using Docker Desktop (macOs).