### PR TITLE
Add OSX support

### DIFF
--- a/.ci/has_to_run.sh
+++ b/.ci/has_to_run.sh
@@ -30,18 +30,33 @@ _travis_terminate_unix() {
 }
 
 
+CURRENT_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
+
+if [[ -z ${TRAVIS_PULL_REQUEST_SLUG} ]] ; then
+  echo "This is a branch build"
+  exit(0)
+if
+
+if [[ ${CURRENT_BRANCH} == "master" && !-z ${TRAVIS_PULL_REQUEST_SLUG} ]] ; then
+  echo "This is a master build"
+  exit(0)
+fi
+
+if [[ ${CURRENT_BRANCH} == dependabot* && !-z ${TRAVIS_PULL_REQUEST_SLUG} ]] ; then
+  echo "This is a branch from dependabot"
+  exit(1)
+fi
+
+if [[ ${CURRENT_BRANCH} == renovate* && !-z ${TRAVIS_PULL_REQUEST_SLUG} ]] ; then
+  echo "This is a branch from renovate"
+  exit(1)
+fi
+
 # List of updated files
 git diff master.. --name-only > /tmp/list.txt
 
 echo "Modified files are"
 cat /tmp/list.txt
-
-CURRENT_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
-
-if [[ "${CURRENT_BRANCH}" == "master" ]] ; then
-  echo "We are on master, run ..."
-  exit 0
-fi
 
 LNG=`echo ${FRAMEWORK} | awk -F '.' '{print $1}'`
 FWK=`echo ${FRAMEWORK} | awk -F '.' '{print $2}'`

--- a/.ci/template.mustache
+++ b/.ci/template.mustache
@@ -1,5 +1,5 @@
 # Exit build if no modification found
-before_install: bash .ci/has_to_run.sh || travis_terminate 0
+#before_install: bash .ci/has_to_run.sh || travis_terminate 0
 
 # Use latest ubuntu LTS (18.04)
 dist: bionic

--- a/.ci/template.mustache
+++ b/.ci/template.mustache
@@ -1,12 +1,6 @@
 # Exit build if no modification found
 #before_install: bash .ci/has_to_run.sh || travis_terminate 0
 
-# Use latest ubuntu LTS (18.04)
-dist: bionic
-
-# Use ARM for IPv6
-arch: arm64
-
 services:
   - docker # Use docker to containerize frameworks
   - postgresql # Use postgresql to store data
@@ -30,14 +24,12 @@ script:
   - shards install
   - shards build
   - bin/make config --without-sieger --keep
-
-  - travis_wait 15 bin/neph ${FRAMEWORK} --mode=CI
-
+  - travis_retry bin/neph ${FRAMEWORK} --mode=CI
   - crystal spec
 
 # Push on docker registry if tests are OK
 # This does not work on forks
-after_success: if [ ${TRAVIS_REPO_SLUG} == "the-benchmarker/web-frameworks" ]; then bash .ci/docker_release.sh ; fi
+#after_success: if [ ${TRAVIS_REPO_SLUG} == "the-benchmarker/web-frameworks" ]; then bash .ci/docker_release.sh ; fi
 
 notifications:
   email: false

--- a/.ci/template.mustache
+++ b/.ci/template.mustache
@@ -1,6 +1,11 @@
 # Exit build if no modification found
 before_install: bash .ci/has_to_run.sh || travis_terminate 0
 
+# Multi-OS
+os:
+  - linux
+  - osx
+
 # Use latest ubuntu LTS (18.04)
 dist: bionic
 
@@ -26,7 +31,9 @@ before_script:
 script:
   - shards install
   - shards build
-  - bin/make config --without-sieger --keep
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install docker-machine  ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bin/make config --without-sieger --keep --driver docker-machine ; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bin/make config --without-sieger --keep ; fi
 
   - travis_wait 15 bin/neph ${FRAMEWORK} --mode=CI
 
@@ -34,7 +41,8 @@ script:
 
 # Push on docker registry if tests are OK
 # This does not work on forks
-after_success: if [ ${TRAVIS_REPO_SLUG} == "the-benchmarker/web-frameworks" ]; then bash .ci/docker_release.sh ; fi
+# Temporarily disabled
+#after_success: if [ ${TRAVIS_REPO_SLUG} == "the-benchmarker/web-frameworks" ]; then bash .ci/docker_release.sh ; fi
 
 notifications:
   email: false

--- a/.ci/template.mustache
+++ b/.ci/template.mustache
@@ -1,5 +1,5 @@
 # Exit build if no modification found
-#before_install: bash .ci/has_to_run.sh || travis_terminate 0
+before_install: bash .ci/has_to_run.sh || travis_terminate 0
 
 services:
   - docker # Use docker to containerize frameworks

--- a/.ci/template.mustache
+++ b/.ci/template.mustache
@@ -5,6 +5,8 @@ services:
   - docker # Use docker to containerize frameworks
   - postgresql # Use postgresql to store data
 
+dist: bionic
+
 # This tool is written in crystal
 language: crystal
 

--- a/.ci/template.mustache
+++ b/.ci/template.mustache
@@ -1,13 +1,11 @@
 # Exit build if no modification found
 before_install: bash .ci/has_to_run.sh || travis_terminate 0
 
-# Multi-OS
-os:
-  - linux
-  - osx
-
 # Use latest ubuntu LTS (18.04)
 dist: bionic
+
+# Use ARM for IPv6
+arch: arm64
 
 services:
   - docker # Use docker to containerize frameworks
@@ -31,9 +29,7 @@ before_script:
 script:
   - shards install
   - shards build
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install docker-machine  ; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bin/make config --without-sieger --keep --driver docker-machine ; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bin/make config --without-sieger --keep ; fi
+  - bin/make config --without-sieger --keep
 
   - travis_wait 15 bin/neph ${FRAMEWORK} --mode=CI
 
@@ -41,8 +37,7 @@ script:
 
 # Push on docker registry if tests are OK
 # This does not work on forks
-# Temporarily disabled
-#after_success: if [ ${TRAVIS_REPO_SLUG} == "the-benchmarker/web-frameworks" ]; then bash .ci/docker_release.sh ; fi
+after_success: if [ ${TRAVIS_REPO_SLUG} == "the-benchmarker/web-frameworks" ]; then bash .ci/docker_release.sh ; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 # Exit build if no modification found
 #before_install: bash .ci/has_to_run.sh || travis_terminate 0
 
-# Use latest ubuntu LTS (18.04)
-dist: bionic
-
-# Use ARM for IPv6
-arch: arm64
-
 services:
   - docker # Use docker to containerize frameworks
   - postgresql # Use postgresql to store data
@@ -181,14 +175,12 @@ script:
   - shards install
   - shards build
   - bin/make config --without-sieger --keep
-
-  - travis_wait 15 bin/neph ${FRAMEWORK} --mode=CI
-
+  - travis_retry bin/neph ${FRAMEWORK} --mode=CI
   - crystal spec
 
 # Push on docker registry if tests are OK
 # This does not work on forks
-after_success: if [ ${TRAVIS_REPO_SLUG} == "the-benchmarker/web-frameworks" ]; then bash .ci/docker_release.sh ; fi
+#after_success: if [ ${TRAVIS_REPO_SLUG} == "the-benchmarker/web-frameworks" ]; then bash .ci/docker_release.sh ; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 # Exit build if no modification found
 before_install: bash .ci/has_to_run.sh || travis_terminate 0
 
+# Multi-OS
+os:
+  - linux
+  - osx
+
 # Use latest ubuntu LTS (18.04)
 dist: bionic
 
@@ -130,6 +135,7 @@ env:
       - FRAMEWORK=python.tornado
       - FRAMEWORK=python.cyclone
       - FRAMEWORK=python.nameko
+      - FRAMEWORK=pony.jennet
       - FRAMEWORK=kotlin.kooby
       - FRAMEWORK=kotlin.ktor
       - FRAMEWORK=java.micronaut
@@ -140,7 +146,6 @@ env:
       - FRAMEWORK=java.javalin
       - FRAMEWORK=java.jooby
       - FRAMEWORK=perl.dancer2
-      - FRAMEWORK=pony.jennet
       - FRAMEWORK=fsharp.suave
       - FRAMEWORK=javascript.restana
       - FRAMEWORK=javascript.express
@@ -154,8 +159,10 @@ env:
       - FRAMEWORK=javascript.turbo_polka
       - FRAMEWORK=javascript.foxify
       - FRAMEWORK=javascript.0http
+      - FRAMEWORK=javascript.nestjs-express
       - FRAMEWORK=javascript.polkadot
       - FRAMEWORK=javascript.rayo
+      - FRAMEWORK=javascript.nestjs-fastify
       - FRAMEWORK=javascript.sails
       - FRAMEWORK=javascript.koa
       - FRAMEWORK=javascript.moleculer
@@ -175,7 +182,9 @@ before_script:
 script:
   - shards install
   - shards build
-  - bin/make config --without-sieger --keep
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install docker-machine  ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bin/make config --without-sieger --keep --driver docker-machine ; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bin/make config --without-sieger --keep ; fi
 
   - travis_wait 15 bin/neph ${FRAMEWORK} --mode=CI
 
@@ -183,7 +192,8 @@ script:
 
 # Push on docker registry if tests are OK
 # This does not work on forks
-after_success: if [ ${TRAVIS_REPO_SLUG} == "the-benchmarker/web-frameworks" ]; then bash .ci/docker_release.sh ; fi
+# Temporarily disabled
+#after_success: if [ ${TRAVIS_REPO_SLUG} == "the-benchmarker/web-frameworks" ]; then bash .ci/docker_release.sh ; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 # Exit build if no modification found
 before_install: bash .ci/has_to_run.sh || travis_terminate 0
 
-# Multi-OS
-os:
-  - linux
-  - osx
-
 # Use latest ubuntu LTS (18.04)
 dist: bionic
+
+# Use ARM for IPv6
+arch: arm64
 
 services:
   - docker # Use docker to containerize frameworks
@@ -182,9 +180,7 @@ before_script:
 script:
   - shards install
   - shards build
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install docker-machine  ; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then bin/make config --without-sieger --keep --driver docker-machine ; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bin/make config --without-sieger --keep ; fi
+  - bin/make config --without-sieger --keep
 
   - travis_wait 15 bin/neph ${FRAMEWORK} --mode=CI
 
@@ -192,8 +188,7 @@ script:
 
 # Push on docker registry if tests are OK
 # This does not work on forks
-# Temporarily disabled
-#after_success: if [ ${TRAVIS_REPO_SLUG} == "the-benchmarker/web-frameworks" ]; then bash .ci/docker_release.sh ; fi
+after_success: if [ ${TRAVIS_REPO_SLUG} == "the-benchmarker/web-frameworks" ]; then bash .ci/docker_release.sh ; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Exit build if no modification found
-before_install: bash .ci/has_to_run.sh || travis_terminate 0
+#before_install: bash .ci/has_to_run.sh || travis_terminate 0
 
 # Use latest ubuntu LTS (18.04)
 dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Exit build if no modification found
-#before_install: bash .ci/has_to_run.sh || travis_terminate 0
+before_install: bash .ci/has_to_run.sh || travis_terminate 0
 
 services:
   - docker # Use docker to containerize frameworks

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
   - docker # Use docker to containerize frameworks
   - postgresql # Use postgresql to store data
 
+dist: bionic
+
 # This tool is written in crystal
 language: crystal
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,17 @@ This project aims to be a load benchmarking suite, no more, no less
 + [wrk](https://github.com/wg/wrk) as benchmarking tool, `>= 4.1.0`
 + [postgresql](https://www.postgresql.org) to store data, `>= 10`
 
-:information_source: you need `wrk` **stable**
+:information_source::information_source::information_source::information_source::information_source:
 
-~~~sh
-git clone --branch 4.1.0 https://github.com/wg/wrk
+:warning: On `OSX` you need `docker-machine` to use `docker` containerization
+
+~~~
+brew install docker-machine
+docker-machine create default
+eval $(docker-machine env default)
 ~~~
 
-:warning: `docker` is used for **development** purpose, `production` results will be computed on [DigitalOcean](https://www.digitalocean.com) :warning:
+:information_source::information_source::information_source::information_source::information_source:
 
 ## Usage
 
@@ -105,9 +109,15 @@ bin/db to_readme
 
 ## Results
 
-:information_source:  Updated on **2020-04-20** :information_source:
+:warning::warning::warning::warning:
 
-> Benchmarking with [wrk](https://github.com/ioquatix/wrk)
+[Vapor](https://vapor.codes) is hidden due, see https://github.com/the-benchmarker/web-frameworks/issues/2575
+
+:warning::warning::warning::warning:
+
+:information_source:  Updated on **2020-04-25** :information_source:
+
+> Benchmarking with [wrk](https://github.com/wg/wrk)
    + Threads : 8
    + Timeout : 8
    + Duration : 15s (seconds)
@@ -116,154 +126,159 @@ bin/db to_readme
 
 |    | Language | Framework | Speed (64) | Speed (256) | Speed (512) | Speed (1024) |  Speed (2048) |
 |----|----------|-----------|-----------:|------------:|------------:|-------------:|--------------:|
-| 1 | javascript (13.12)| [nanoexpress](https://github.com/nanoexpress/nanoexpress) (2.0) | 176 480 | 188 358 | 188 735 | 185 362 | 186 495 |
-| 2 | php (7.4)| [simps](https://simps.io) (1.0) | 175 011 | 184 006 | 185 336 | 183 139 | 183 520 |
-| 3 | javascript (13.12)| [nanoexpress-pro](https://github.com/nanoexpress/pro) (1.11) | 174 700 | 195 865 | 194 737 | 192 160 | 189 753 |
-| 4 | javascript (13.12)| [sifrr](https://sifrr.github.io/sifrr/#/./packages/server/sifrr-server/) (0.0) | 172 624 | 185 454 | 184 938 | 183 964 | 179 356 |
-| 5 | nim (1.0)| [httpbeast](https://github.com/dom96/httpbeast) (2.2) | 170 899 | 190 062 | 188 898 | 180 806 | 178 524 |
-| 6 | java (8)| [rapidoid](https://rapidoid.org) (5.5) | 159 160 | 175 603 | 177 087 | 173 003 | 173 583 |
-| 7 | go (1.14)| [fasthttp](https://pkg.go.dev/github.com/valyala/fasthttp) (1.11) | 158 037 | 167 193 | 170 783 | 166 167 | 165 804 |
-| 8 | crystal (0.34)| [toro](https://github.com/soveran/toro) (0.4) | 153 642 | 161 116 | 157 831 | 150 055 | 149 362 |
-| 9 | crystal (0.34)| [router.cr](https://github.com/tbrand/router.cr) (0.2) | 152 034 | 158 954 | 155 072 | 147 408 | 146 932 |
-| 10 | go (1.14)| [fasthttprouter](https://pkg.go.dev/github.com/buaazp/fasthttprouter) (0.1) | 151 590 | 160 664 | 164 024 | 159 057 | 158 394 |
-| 11 | go (1.14)| [atreugo](https://github.com/savsgio/atreugo/blob/master/docs/README.md) (11.0) | 151 507 | 160 256 | 163 637 | 158 352 | 157 699 |
-| 12 | go (1.14)| [router](https://pkg.go.dev/github.com/fasthttp/router) (1.0) | 151 293 | 160 121 | 163 033 | 158 822 | 158 950 |
-| 13 | go (1.14)| [gorouter-fasthttp](https://github.com/vardius/gorouter/wiki) (4.4) | 150 864 | 159 401 | 162 769 | 158 318 | 158 152 |
-| 14 | php (7.4)| [workerman](https://github.com/walkor/Workerman) (4.0) | 149 943 | 161 774 | 162 538 | 160 888 | 160 059 |
-| 15 | crystal (0.34)| [ricr](https://ricr-web.github.io/ricr) (0.1) | 149 659 | 156 334 | 153 443 | 145 360 | 145 602 |
-| 16 | crystal (0.34)| [spider-gazelle](https://spider-gazelle.net) (2.4) | 147 007 | 153 170 | 150 206 | 142 712 | 141 645 |
-| 17 | go (1.14)| [fiber](https://fiber.wiki) (1.9) | 146 496 | 155 222 | 153 256 | 145 240 | 145 896 |
-| 18 | crystal (0.34)| [kemal](https://kemalcr.com) (0.26) | 142 616 | 148 154 | 144 306 | 137 202 | 136 956 |
-| 19 | crystal (0.34)| [grip](https://github.com/grip-framework/grip) (0.28) | 141 236 | 146 562 | 143 217 | 135 769 | 133 980 |
-| 20 | rust (1.42)| [actix](https://actix.rs) (2.0) | 137 842 | 140 616 | 138 748 | 134 474 | 131 617 |
-| 21 | crystal (0.34)| [amber](https://amberframework.org) (0.34) | 135 548 | 140 923 | 136 965 | 130 755 | 129 942 |
-| 22 | nim (1.0)| [jester](https://github.com/dom96/jester) (0.4) | 134 609 | 144 172 | 140 210 | 138 463 | 141 104 |
-| 23 | crystal (0.34)| [orion](https://github.com/obsidian/orion) (2.3) | 130 205 | 133 417 | 127 882 | 119 018 | 117 671 |
-| 24 | crystal (0.34)| [lucky](https://luckyframework.org) (0.20) | 128 518 | 132 287 | 126 471 | 117 683 | 116 672 |
-| 25 | crystal (0.34)| [athena](https://github.com/athena-framework/athena) (0.8) | 123 688 | 126 159 | 119 153 | 107 094 | 107 007 |
-| 26 | java (8)| [act](https://actframework.org) (1.8) | 117 627 | 126 512 | 131 558 | 129 414 | 129 922 |
-| 27 | c (11)| [agoo-c](https://github.com/ohler55/agoo-c) (0.7) | 110 947 | 173 013 | 154 557 | 178 089 | 178 808 |
-| 28 | go (1.14)| [rte](https://github.com/jwilner/rte) (0.0) | 107 816 | 107 895 | 111 192 | 110 913 | 110 709 |
-| 29 | go (1.14)| [httprouter](https://pkg.go.dev/github.com/julienschmidt/httprouter) (1.3) | 106 310 | 106 445 | 109 465 | 108 887 | 108 996 |
-| 30 | go (1.14)| [gorouter](https://github.com/vardius/gorouter/wiki) (4.4) | 101 951 | 105 880 | 108 497 | 107 320 | 106 410 |
-| 31 | go (1.14)| [chi](https://github.com/go-chi/chi) (4.1) | 101 868 | 101 171 | 104 288 | 103 876 | 103 099 |
-| 32 | go (1.14)| [aero](https://github.com/aerogo/aero) (1.3) | 100 028 | 100 942 | 103 730 | 102 991 | 103 125 |
-| 33 | ruby (2.7)| [agoo](https://github.com/ohler55/agoo) (2.12) | 98 790 | 117 828 | 121 786 | 122 307 | 121 220 |
-| 34 | go (1.14)| [violetear](https://violetear.org) (7.0) | 98 553 | 98 978 | 102 169 | 102 086 | 102 086 |
-| 35 | go (1.14)| [goroute](https://goroute.github.io) (0.0) | 98 210 | 96 895 | 100 171 | 100 663 | 100 499 |
-| 36 | go (1.14)| [kami](https://github.com/guregu/kami) (2.2) | 97 764 | 102 020 | 103 638 | 101 596 | 101 161 |
-| 37 | go (1.14)| [echo](https://echo.labstack.com) (4.1) | 97 751 | 96 808 | 99 612 | 99 919 | 99 592 |
-| 38 | go (1.14)| [gorilla-mux](https://www.gorillatoolkit.org/pkg/mux) (1.7) | 94 585 | 93 144 | 96 179 | 96 649 | 96 357 |
-| 39 | go (1.14)| [beego](https://beego.me) (1.12) | 94 506 | 98 005 | 100 921 | 100 590 | 100 916 |
-| 40 | go (1.14)| [gin](https://gin-gonic.com) (1.6) | 93 329 | 97 230 | 99 266 | 99 329 | 98 836 |
-| 41 | go (1.14)| [webgo](https://github.com/bnkamalesh/webgo) (3.0) | 92 732 | 92 216 | 95 206 | 95 734 | 95 544 |
-| 42 | csharp (8.0)| [aspnetcore](https://docs.microsoft.com/en-us/aspnet/index) (3.1) | 91 571 | 98 459 | 99 249 | 97 903 | 98 203 |
-| 43 | javascript (13.12)| [polkadot](https://github.com/lukeed/polkadot) (1.0) | 88 455 | 98 138 | 99 654 | 95 575 | 91 766 |
-| 44 | cpp (14/17)| [drogon](https://github.com/an-tao/drogon) (1.0) | 87 973 | 90 895 | 92 481 | 92 104 | 91 346 |
-| 45 | javascript (13.12)| [0http](https://github.com/jkyberneees/0http) (2.2) | 85 589 | 97 823 | 98 409 | 94 424 | 90 408 |
-| 46 | javascript (13.12)| [restana](https://github.com/jkyberneees/ana) (4.3) | 84 558 | 92 500 | 92 583 | 88 771 | 87 519 |
-| 47 | javascript (13.12)| [polka](https://github.com/lukeed/polka) (0.5) | 81 334 | 83 534 | 82 916 | 81 545 | 81 379 |
-| 48 | go (1.14)| [air](https://github.com/aofei/air) (0.15) | 80 150 | 84 672 | 86 190 | 86 081 | 86 186 |
-| 49 | javascript (13.12)| [rayo](https://rayo.js.org) (1.3) | 79 565 | 85 123 | 82 992 | 80 288 | 79 129 |
-| 50 | swift (5.2)| [perfect](https://perfect.org) (3.1) | 75 803 | 82 548 | 87 821 | 88 729 | 87 911 |
-| 51 | java (8)| [javalin](https://javalin.io) (3.8) | 75 081 | 79 473 | 82 427 | 81 748 | 82 627 |
-| 52 | go (1.14)| [gf](https://goframe.org) (1.12) | 74 485 | 79 783 | 81 141 | 81 154 | 81 108 |
-| 53 | scala (2.12)| [akkahttp](https://akka.io) (10.1) | 74 020 | 77 582 | 74 163 | 73 604 | 74 429 |
-| 54 | c (99)| [kore](https://kore.io) (3.3) | 72 311 | 109 633 | 140 002 | 141 963 | 131 942 |
-| 55 | python (3.8)| [falcon](https://falconframework.org) (2.0) | 71 597 | 74 774 | 76 223 | 75 211 | 75 111 |
-| 56 | javascript (13.12)| [muneem](https://github.com/node-muneem/muneem) (2.4) | 67 747 | 72 508 | 70 420 | 68 846 | 68 527 |
-| 57 | java (8)| [spring-boot](https://spring.io/projects/spring-boot) (2.2) | 67 348 | 74 296 | 72 568 | 71 101 | 72 137 |
-| 58 | php (7.4)| [hyperf](https://www.hyperf.io) (1.1) | 66 590 | 68 638 | 69 132 | 68 638 | 68 840 |
-| 59 | javascript (13.12)| [fastify](https://fastify.io) (2.13) | 66 417 | 71 335 | 67 668 | 66 355 | 66 843 |
-| 60 | javascript (13.12)| [foxify](https://foxify.js.org) (0.1) | 65 642 | 68 879 | 68 337 | 66 431 | 65 640 |
-| 61 | kotlin (1.3)| [ktor](https://ktor.io) (1.2) | 64 255 | 72 528 | 79 953 | 81 115 | 79 840 |
-| 62 | java (8)| [micronaut](https://micronaut.io) (1.2) | 63 262 | 73 668 | 71 238 | 69 047 | 68 011 |
-| 63 | php (7.4)| [one](https://github.com/lizhichao/one) (2.0) | 63 221 | 66 669 | 67 240 | 67 157 | 67 137 |
-| 64 | elixir (1.1)| [cowboy_stream](https://ninenines.eu/docs/en/cowboy/2.7/guide/streams/) (2.7) | 63 212 | 63 481 | 62 915 | 61 315 | 61 175 |
-| 65 | go (1.14)| [mars](https://github.com/roblillack/mars) (1.0) | 61 134 | 63 701 | 66 416 | 66 526 | 66 268 |
-| 66 | javascript (13.12)| [koa](https://koajs.com) (2.11) | 59 767 | 62 271 | 60 865 | 59 989 | 58 280 |
-| 67 | python (3.8)| [bottle](https://bottlepy.org) (0.12) | 58 934 | 61 810 | 62 239 | 60 875 | 61 433 |
-| 68 | javascript (13.12)| [iotjs-express](https://github.com/SamsungInternet/iotjs-express) (0.0) | 58 695 | 61 087 | 59 901 | 57 692 | 58 050 |
-| 69 | swift (5.2)| [vapor](https://vapor.codes) (3.3) | 56 474 | 57 715 | 57 726 | 56 869 | 56 626 |
-| 70 | swift (5.2)| [kitura-nio](https://kitura.io) (2.9) | 55 674 | 55 291 | 55 603 | 54 403 | 54 610 |
-| 71 | python (3.8)| [apidaora](https://github.com/dutradda/apidaora) (0.26) | 55 395 | 60 370 | 60 020 | 57 912 | 57 728 |
-| 72 | rust (1.42)| [nickel](https://nickel-org.github.io) (0.11) | 55 224 | 54 270 | 53 596 | 54 322 | 54 445 |
-| 73 | java (8)| [spring-framework](https://spring.io/projects/spring-framework) (5.2) | 54 962 | 63 594 | 63 558 | 63 586 | 63 404 |
-| 74 | swift (5.2)| [kitura](https://kitura.io) (2.9) | 54 878 | 54 699 | 54 887 | 53 933 | 53 604 |
-| 75 | javascript (13.12)| [express](https://expressjs.com) (4.17) | 54 464 | 56 950 | 55 707 | 54 534 | 54 250 |
-| 76 | clojure (1.1)| [coast](https://coastonclojure.com) (1.0) | 54 270 | 55 317 | 55 258 | 54 871 | 54 910 |
-| 77 | javascript (13.12)| [feathersjs](https://feathersjs.com) (4.5) | 53 621 | 56 520 | 54 711 | 54 450 | 53 904 |
-| 78 | scala (2.12)| [http4s](https://http4s.org) (0.18) | 52 787 | 59 651 | 61 914 | 62 317 | 62 487 |
-| 79 | python (3.8)| [blacksheep](https://github.com/RobertoPrevato/BlackSheep) (0.2) | 49 496 | 53 417 | 53 332 | 51 425 | 51 305 |
-| 80 | python (3.8)| [pyramid](https://trypyramid.com) (1.1) | 48 925 | 51 305 | 51 747 | 50 822 | 50 688 |
-| 81 | javascript (13.12)| [moleculer](https://moleculer.services) (0.14) | 48 265 | 49 667 | 46 743 | 46 337 | 47 788 |
-| 82 | python (3.8)| [asgineer](https://asgineer.readthedocs.io) (0.7) | 47 824 | 57 397 | 57 414 | 55 495 | 55 500 |
-| 83 | cpp (11)| [evhtp](https://criticalstack.com) (1.2) | 46 672 | 46 761 | 46 855 | 46 200 | 45 789 |
-| 84 | python (3.8)| [hug](https://hug.rest) (2.6) | 45 646 | 48 584 | 48 581 | 48 056 | 48 067 |
-| 85 | python (3.8)| [starlette](https://starlette.io) (0.13) | 44 598 | 48 268 | 47 880 | 46 410 | 46 193 |
-| 86 | rust (1.42)| [gotham](https://gotham.rs) (0.4) | 42 326 | 49 900 | 51 624 | 53 143 | 52 999 |
-| 87 | javascript (13.12)| [hapi](https://hapijs.com) (19.1) | 41 197 | 43 479 | 42 876 | 43 182 | 41 871 |
-| 88 | php (7.4)| [imi](https://imiphp.com) (1.0) | 40 611 | 42 143 | 42 346 | 42 489 | 42 654 |
-| 89 | elixir (1.1)| [cowboy](https://ninenines.eu/docs/en/cowboy/2.7/guide/) (2.7) | 39 557 | 38 710 | 39 113 | 36 615 | 36 271 |
-| 90 | javascript (13.12)| [restify](https://restify.com) (8.5) | 39 300 | 41 416 | 40 522 | 40 618 | 40 908 |
-| 91 | ruby (2.7)| [syro](https://github.com/soveran/syro) (3.2) | 39 050 | 40 891 | 39 048 | 38 352 | 38 801 |
-| 92 | ruby (2.7)| [hanami-api](https://hanamirb.org) (0.1) | 38 875 | 39 061 | 37 047 | 36 727 | 37 133 |
-| 93 | python (3.8)| [emmett](https://github.com/emmett-framework/emmett) (2.0.0b2) | 37 869 | 41 225 | 41 096 | 39 624 | 39 512 |
-| 94 | php (7.4)| [sw-fw-less](https://github.com/luoxiaojun1992/sw-fw-less) (preview) | 37 802 | 40 704 | 40 745 | 40 183 | 40 255 |
-| 95 | ruby (2.7)| [roda](https://roda.jeremyevans.net) (3.31) | 36 434 | 36 716 | 35 205 | 35 155 | 35 165 |
-| 96 | php (7.4)| [swoft](https://swoft.org) (2.0) | 36 207 | 37 201 | 37 186 | 36 724 | 36 693 |
-| 97 | elixir (1.1)| [plug](https://hexdocs.pm/plug) (1.10) | 35 837 | 36 414 | 36 338 | 35 012 | 35 029 |
-| 98 | ruby (2.7)| [cuba](https://cuba.is) (3.9) | 33 088 | 33 684 | 32 742 | 32 453 | 32 525 |
-| 99 | dart (2.7)| [aqueduct](https://aqueduct.io) (3.3) | 31 498 | 30 734 | 31 466 | 30 901 | 30 909 |
-| 100 | elixir (1.1)| [phoenix](https://phoenixframework.org) (1.4) | 31 035 | 31 348 | 30 786 | 30 043 | 30 007 |
-| 101 | python (3.8)| [fastapi](https://fastapi.tiangolo.com) (0.54) | 29 661 | 31 347 | 31 241 | 30 019 | 29 981 |
-| 102 | crystal (0.34)| [shivneri](https://github.com/ujjwalguptaofficial/shivneri) (0.15) | 28 730 | 27 107 | 24 853 | 22 451 | 21 387 |
-| 103 | python (3.8)| [responder](https://python-responder.org) (2.0) | 28 665 | 30 806 | 30 556 | 29 411 | 29 462 |
-| 104 | ruby (2.7)| [rack_app](https://rack-app.com) (7.6) | 27 838 | 27 779 | 27 153 | 27 132 | 27 154 |
-| 105 | ruby (2.7)| [rack-routing](https://github.com/georgeu2000/rack-routing) (0.0) | 27 291 | 27 449 | 26 891 | 26 826 | 26 861 |
-| 106 | python (3.8)| [clastic](https://github.com/mahmoud/clastic) (19.9) | 25 367 | 26 297 | 25 998 | 25 826 | 25 772 |
-| 107 | python (3.8)| [molten](https://moltenframework.com) (1.0) | 25 355 | 26 496 | 26 898 | 26 624 | 25 822 |
-| 108 | ruby (2.7)| [camping](https://github.com/camping/camping) (2.1) | 25 226 | 24 619 | 24 218 | 24 149 | 24 222 |
-| 109 | python (3.8)| [aiohttp](https://aiohttp.readthedocs.io) (3.6) | 24 740 | 27 294 | 27 299 | 26 463 | 26 474 |
-| 110 | fsharp (4.7)| [suave](https://suave.io) (2.5) | 23 994 | 26 850 | 30 109 | 34 728 | 34 650 |
-| 111 | rust (1.42)| [iron](https://ironframework.io) (0.6) | 23 902 | 23 908 | 24 084 | 23 832 | 23 863 |
-| 112 | python (3.8)| [masonite](https://masoniteproject.com) (2.3) | 23 744 | 24 716 | 24 600 | 24 196 | 24 021 |
-| 113 | javascript (13.12)| [turbo_polka](https://github.com/mafintosh/turbo-http) (0.3) | 22 685 | 21 826 | 20 552 | 20 348 | 20 388 |
-| 114 | python (3.8)| [flask](https://flask.pocoo.org) (1.1) | 22 558 | 24 272 | 24 322 | 23 846 | 21 235 |
-| 115 | python (3.8)| [sanic](https://github.com/huge-success/sanic) (19.12) | 18 405 | 18 886 | 18 469 | 18 160 | 18 044 |
-| 116 | php (7.4)| [spiral](https://github.com/spiral/framework) (2.4) | 18 232 | 18 674 | 18 716 | 18 504 | 18 626 |
-| 117 | go (1.14)| [tango](https://gitea.com/lunny/tango) (0.6) | 17 179 | 17 626 | 17 666 | 17 635 | 17 646 |
-| 118 | ruby (2.7)| [sinatra](https://sinatrarb.com) (2.0) | 15 768 | 15 757 | 15 666 | 15 676 | 15 654 |
-| 119 | ruby (2.7)| [grape](https://ruby-grape.org) (1.3) | 14 583 | 14 531 | 14 630 | 14 609 | 14 540 |
-| 120 | javascript (13.12)| [sails](https://sailsjs.com) (1.2) | 12 544 | 12 985 | 13 012 | 12 929 | 13 009 |
-| 121 | swift (5.2)| [swifter](https://github.com/httpswift/swifter) (1.4) | 12 204 | 12 176 | 12 112 | 12 163 | 12 236 |
-| 122 | ruby (2.7)| [flame](https://github.com/AlexWayfer/flame) (4.18) | 11 516 | 11 293 | 11 288 | 11 265 | 11 189 |
-| 123 | ruby (2.7)| [hanami](https://hanamirb.org) (1.3) | 10 725 | 10 638 | 10 638 | 10 579 | 10 598 |
-| 124 | python (3.8)| [quart](https://pgjones.gitlab.io/quart) (0.11) | 10 524 | 11 002 | 9 702 | 9 562 | 9 720 |
-| 125 | python (3.8)| [django](https://djangoproject.com) (3.0) | 9 919 | 9 566 | 9 873 | 8 889 | 9 694 |
-| 126 | php (7.4)| [ubiquity](https://ubiquity.kobject.net) (2.3) | 9 192 | 9 073 | 8 869 | 51 167 | 49 026 |
-| 127 | python (3.8)| [tornado](https://tornadoweb.org) (6.0) | 8 447 | 10 019 | 10 011 | 9 740 | 9 899 |
-| 128 | php (7.4)| [one-fpm](https://github.com/lizhichao/one) (2.0) | 7 944 | 7 947 | 7 778 | 43 169 | 41 620 |
-| 129 | python (3.8)| [cherrypy](https://github.com/cherrypy/cherrypy) (18.6) | 7 647 | 9 162 | 9 089 | 8 986 | 9 020 |
-| 130 | php (7.4)| [phalcon](https://phalcon.io) (4.0) | 7 542 | 7 513 | 7 423 | 51 408 | 48 966 |
-| 131 | php (7.4)| [hamlet](https://github.com/vasily-kartashov/hamlet-core) (3.2) | 7 498 | 7 505 | 7 481 | 43 986 | 43 970 |
-| 132 | go (1.14)| [gramework](https://github.com/gramework/gramework) (1.7) | 6 165 | 9 865 | 7 575 | 3 820 | 0 |
-| 133 | php (7.4)| [chubbyphp](https://github.com/chubbyphp/chubbyphp-framework) (2.8) | 5 619 | 5 609 | 5 793 | 43 571 | 42 651 |
-| 134 | crystal (0.34)| [onyx](https://onyxframework.org) (0.5) | 4 912 | 5 034 | 5 026 | 5 109 | 5 149 |
-| 135 | php (7.4)| [slim](https://slimframework.com) (4.5) | 4 658 | 4 712 | 4 732 | 43 220 | 40 718 |
-| 136 | php (7.4)| [lumen](https://lumen.laravel.com) (7.0) | 4 323 | 4 318 | 4 407 | 41 646 | 37 498 |
-| 137 | php (7.4)| [yii](https://yiiframework.com) (2.0) | 4 142 | 4 122 | 4 204 | 42 437 | 39 424 |
-| 138 | ruby (2.7)| [rails](https://rubyonrails.org) (6.0) | 3 747 | 3 540 | 3 540 | 3 511 | 3 523 |
-| 139 | php (7.4)| [symfony](https://symfony.com) (4.3) | 3 183 | 3 187 | 3 216 | 41 467 | 39 102 |
-| 140 | php (7.4)| [mezzio](https://docs.mezzio.dev) (3.2) | 2 775 | 2 789 | 2 847 | 39 311 | 40 397 |
-| 141 | julia (1.4)| [merly](https://github.com/codeneomatrix/Merly.jl) (0.2) | 2 655 | 8 211 | 6 495 | 5 121 | 3 216 |
-| 142 | python (3.8)| [cyclone](https://cyclone.io) (1.3) | 2 434 | 2 428 | 2 428 | 2 430 | 2 373 |
-| 143 | python (3.8)| [klein](https://github.com/twisted/klein) (19.6) | 1 615 | 1 632 | 1 614 | 1 605 | 1 602 |
-| 144 | python (3.8)| [nameko](https://github.com/nameko/nameko) (2.12) | 1 585 | 1 526 | 1 515 | 1 510 | 1 518 |
-| 145 | perl (5.3)| [dancer2](https://perldancer.org) (2.0) | 1 505 | 1 533 | 1 044 | 1 727 | 1 063 |
-| 146 | php (7.4)| [laminas](https://getlaminas.org) (3.1) | 1 433 | 1 467 | 1 504 | 38 293 | 36 990 |
-| 147 | php (7.4)| [basicphp](https://github.com/ray-ang/basicphp) (0.9) | 464 | 421 | 2 543 | 35 786 | 32 772 |
-| 148 | php (7.4)| [laravel](https://laravel.com) (7.6) | 209 | 154 | 2 571 | 22 917 | 21 052 |
+| 1 | javascript (13.13)| [nanoexpress-pro](https://github.com/nanoexpress/pro) (1.11) | 189 060 | 202 174 | 203 477 | 200 578 | 201 275 |
+| 2 | java (8)| [jooby](https://jooby.io) (2.8) | 177 169 | 192 009 | 192 372 | 187 952 | 186 744 |
+| 3 | php (7.4)| [simps](https://simps.io) (1.0) | 175 340 | 188 260 | 188 754 | 186 367 | 186 112 |
+| 4 | nim (1.2)| [httpbeast](https://github.com/dom96/httpbeast) (2.2) | 174 113 | 183 620 | 189 253 | 181 532 | 176 198 |
+| 5 | javascript (13.13)| [nanoexpress](https://github.com/nanoexpress/nanoexpress) (2.0) | 173 379 | 187 522 | 191 206 | 188 782 | 181 822 |
+| 6 | javascript (13.13)| [sifrr](https://sifrr.github.io/sifrr/#/./packages/server/sifrr-server/) (0.0) | 171 506 | 182 071 | 177 896 | 177 850 | 179 866 |
+| 7 | kotlin (1.3)| [kooby](https://jooby.io) (2.8) | 166 517 | 179 340 | 178 584 | 172 893 | 174 029 |
+| 8 | go (1.14)| [fasthttp](https://pkg.go.dev/github.com/valyala/fasthttp) (1.12) | 157 297 | 166 028 | 170 036 | 164 130 | 165 029 |
+| 9 | crystal (0.34)| [toro](https://github.com/soveran/toro) (0.4) | 155 740 | 162 265 | 158 221 | 150 296 | 144 652 |
+| 10 | java (8)| [rapidoid](https://rapidoid.org) (5.5) | 155 319 | 170 737 | 170 596 | 165 492 | 163 963 |
+| 11 | go (1.14)| [fiber](https://fiber.wiki) (1.9) | 154 440 | 156 657 | 153 953 | 145 559 | 143 858 |
+| 12 | crystal (0.34)| [router.cr](https://github.com/tbrand/router.cr) (0.2) | 153 641 | 160 439 | 157 012 | 148 385 | 148 241 |
+| 13 | go (1.14)| [router](https://pkg.go.dev/github.com/fasthttp/router) (1.0) | 152 808 | 161 500 | 164 613 | 159 551 | 159 193 |
+| 14 | go (1.14)| [gorouter-fasthttp](https://github.com/vardius/gorouter/wiki) (4.4) | 152 309 | 161 081 | 164 241 | 158 572 | 158 726 |
+| 15 | crystal (0.34)| [ricr](https://ricr-web.github.io/ricr) (0.1) | 151 385 | 157 842 | 154 245 | 145 201 | 145 038 |
+| 16 | go (1.14)| [atreugo](https://github.com/savsgio/atreugo/blob/master/docs/README.md) (11.0) | 151 366 | 160 771 | 163 650 | 159 225 | 157 821 |
+| 17 | go (1.14)| [fasthttprouter](https://pkg.go.dev/github.com/buaazp/fasthttprouter) (0.1) | 150 680 | 160 804 | 163 363 | 158 717 | 158 364 |
+| 18 | crystal (0.34)| [spider-gazelle](https://spider-gazelle.net) (2.4) | 150 292 | 156 759 | 152 674 | 144 641 | 144 460 |
+| 19 | php (7.4)| [workerman](https://github.com/walkor/Workerman) (4.0) | 150 253 | 162 295 | 163 717 | 161 432 | 160 828 |
+| 20 | crystal (0.34)| [kemal](https://kemalcr.com) (0.26) | 143 804 | 149 795 | 146 678 | 139 006 | 138 021 |
+| 21 | crystal (0.34)| [grip](https://github.com/grip-framework/grip) (0.28) | 139 993 | 145 587 | 142 003 | 133 362 | 132 163 |
+| 22 | crystal (0.34)| [amber](https://amberframework.org) (0.34) | 136 214 | 141 399 | 136 314 | 129 734 | 129 393 |
+| 23 | rust (1.43)| [actix](https://actix.rs) (2.0) | 135 759 | 135 732 | 135 910 | 127 947 | 125 941 |
+| 24 | crystal (0.34)| [lucky](https://luckyframework.org) (0.20) | 131 195 | 134 749 | 129 946 | 121 007 | 120 864 |
+| 25 | crystal (0.34)| [orion](https://github.com/obsidian/orion) (2.3) | 130 428 | 133 571 | 128 184 | 117 359 | 116 183 |
+| 26 | crystal (0.34)| [athena](https://github.com/athena-framework/athena) (0.8) | 124 893 | 126 745 | 120 456 | 108 021 | 106 410 |
+| 27 | nim (1.2)| [jester](https://github.com/dom96/jester) (0.4) | 123 389 | 135 256 | 138 305 | 134 002 | 134 786 |
+| 28 | java (8)| [act](https://actframework.org) (1.8) | 119 178 | 131 643 | 131 489 | 127 967 | 127 812 |
+| 29 | c (11)| [agoo-c](https://github.com/ohler55/agoo-c) (0.7) | 116 280 | 175 914 | 180 039 | 179 885 | 173 035 |
+| 30 | go (1.14)| [rte](https://github.com/jwilner/rte) (0.0) | 107 860 | 107 947 | 110 964 | 110 794 | 110 259 |
+| 31 | go (1.14)| [httprouter](https://pkg.go.dev/github.com/julienschmidt/httprouter) (1.3) | 106 314 | 106 258 | 109 478 | 109 169 | 109 024 |
+| 32 | go (1.14)| [gorouter](https://github.com/vardius/gorouter/wiki) (4.4) | 102 176 | 106 448 | 108 211 | 107 606 | 106 917 |
+| 33 | go (1.14)| [chi](https://github.com/go-chi/chi) (4.1) | 102 118 | 101 260 | 104 318 | 103 935 | 103 549 |
+| 34 | c (99)| [kore](https://kore.io) (3.3) | 101 709 | 138 236 | 148 289 | 139 627 | 150 174 |
+| 35 | go (1.14)| [aero](https://github.com/aerogo/aero) (1.3) | 99 909 | 101 202 | 103 787 | 102 954 | 102 603 |
+| 36 | go (1.14)| [violetear](https://violetear.org) (7.0) | 99 191 | 99 601 | 102 681 | 102 587 | 102 244 |
+| 37 | go (1.14)| [goroute](https://goroute.github.io) (0.0) | 98 473 | 97 098 | 100 168 | 100 313 | 99 530 |
+| 38 | go (1.14)| [kami](https://github.com/guregu/kami) (2.2) | 98 311 | 102 440 | 104 027 | 102 103 | 102 135 |
+| 39 | go (1.14)| [echo](https://echo.labstack.com) (4.1) | 97 681 | 97 372 | 100 053 | 100 206 | 99 686 |
+| 40 | ruby (2.7)| [agoo](https://github.com/ohler55/agoo) (2.12) | 96 537 | 114 345 | 117 737 | 118 212 | 117 410 |
+| 41 | go (1.14)| [gorilla-mux](https://www.gorillatoolkit.org/pkg/mux) (1.7) | 95 603 | 93 662 | 96 951 | 97 363 | 96 604 |
+| 42 | csharp (8.0)| [aspnetcore](https://docs.microsoft.com/en-us/aspnet/index) (3.1) | 94 701 | 101 953 | 102 560 | 100 267 | 101 301 |
+| 43 | go (1.14)| [beego](https://beego.me) (1.12) | 94 197 | 97 335 | 100 653 | 100 400 | 99 893 |
+| 44 | go (1.14)| [gin](https://gin-gonic.com) (1.6) | 93 430 | 97 573 | 100 268 | 99 304 | 98 521 |
+| 45 | go (1.14)| [webgo](https://github.com/bnkamalesh/webgo) (3.0) | 93 201 | 92 473 | 93 505 | 94 133 | 95 877 |
+| 46 | cpp (14/17)| [drogon](https://github.com/an-tao/drogon) (1.0) | 88 291 | 91 994 | 92 946 | 92 283 | 92 211 |
+| 47 | javascript (13.13)| [0http](https://github.com/jkyberneees/0http) (2.2) | 85 205 | 92 906 | 93 557 | 88 176 | 86 124 |
+| 48 | javascript (13.13)| [polka](https://github.com/lukeed/polka) (0.5) | 82 588 | 87 449 | 85 228 | 83 428 | 82 504 |
+| 49 | javascript (13.13)| [restana](https://github.com/jkyberneees/ana) (4.3) | 81 821 | 90 649 | 91 853 | 89 284 | 88 131 |
+| 50 | javascript (13.13)| [polkadot](https://github.com/lukeed/polkadot) (1.0) | 80 817 | 92 474 | 92 099 | 87 130 | 86 858 |
+| 51 | go (1.14)| [air](https://github.com/aofei/air) (0.15) | 80 257 | 84 257 | 85 789 | 85 900 | 85 887 |
+| 52 | scala (2.12)| [akkahttp](https://akka.io) (10.1) | 78 136 | 86 631 | 83 988 | 83 034 | 81 671 |
+| 53 | javascript (13.13)| [rayo](https://rayo.js.org) (1.3) | 75 513 | 78 635 | 78 424 | 75 569 | 74 314 |
+| 54 | go (1.14)| [gf](https://goframe.org) (1.12) | 75 416 | 80 673 | 82 228 | 81 999 | 81 255 |
+| 55 | java (8)| [javalin](https://javalin.io) (3.8) | 73 926 | 78 921 | 78 268 | 77 290 | 77 729 |
+| 56 | swift (5.2)| [perfect](https://perfect.org) (3.1) | 71 404 | 80 439 | 85 863 | 86 081 | 84 225 |
+| 57 | javascript (13.13)| [muneem](https://github.com/node-muneem/muneem) (2.4) | 68 572 | 73 154 | 71 932 | 69 963 | 69 890 |
+| 58 | python (3.8)| [falcon](https://falconframework.org) (2.0) | 68 043 | 75 656 | 75 950 | 74 336 | 74 458 |
+| 59 | kotlin (1.3)| [ktor](https://ktor.io) (1.2) | 65 724 | 76 664 | 78 316 | 77 520 | 77 258 |
+| 60 | php (7.4)| [hyperf](https://www.hyperf.io) (1.1) | 65 635 | 68 650 | 69 162 | 68 689 | 68 739 |
+| 61 | javascript (13.13)| [foxify](https://foxify.js.org) (0.1) | 65 502 | 68 990 | 67 622 | 65 821 | 65 479 |
+| 62 | java (8)| [spring-boot](https://spring.io/projects/spring-boot) (2.2) | 65 495 | 71 774 | 70 658 | 69 632 | 69 020 |
+| 63 | javascript (13.13)| [fastify](https://fastify.io) (2.13) | 65 376 | 71 486 | 69 053 | 66 226 | 66 805 |
+| 64 | java (8)| [micronaut](https://micronaut.io) (1.2) | 62 511 | 68 702 | 68 274 | 65 698 | 65 750 |
+| 65 | php (7.4)| [one](https://github.com/lizhichao/one) (2.0) | 61 398 | 67 368 | 67 478 | 67 141 | 66 843 |
+| 66 | go (1.14)| [mars](https://github.com/roblillack/mars) (1.0) | 60 746 | 63 792 | 65 879 | 66 456 | 66 121 |
+| 67 | elixir (1.1)| [cowboy_stream](https://ninenines.eu/docs/en/cowboy/2.7/guide/streams/) (2.7) | 59 667 | 61 738 | 60 174 | 58 949 | 59 158 |
+| 68 | javascript (13.13)| [koa](https://koajs.com) (2.11) | 59 191 | 62 583 | 60 423 | 59 187 | 60 360 |
+| 69 | python (3.8)| [bottle](https://bottlepy.org) (0.12) | 57 203 | 60 859 | 61 082 | 60 082 | 60 004 |
+| 70 | javascript (13.13)| [iotjs-express](https://github.com/SamsungInternet/iotjs-express) (0.0) | 56 232 | 60 630 | 59 427 | 56 048 | 55 444 |
+| 71 | python (3.8)| [apidaora](https://github.com/dutradda/apidaora) (0.26) | 56 173 | 61 192 | 61 252 | 58 709 | 58 692 |
+| 72 | rust (1.43)| [nickel](https://nickel-org.github.io) (0.11) | 55 519 | 56 168 | 55 104 | 55 544 | 55 496 |
+| 73 | java (8)| [spring-framework](https://spring.io/projects/spring-framework) (5.2) | 55 045 | 63 253 | 62 459 | 62 187 | 61 654 |
+| 74 | javascript (13.13)| [feathersjs](https://feathersjs.com) (4.5) | 54 634 | 57 121 | 55 341 | 54 653 | 54 588 |
+| 75 | javascript (13.13)| [express](https://expressjs.com) (4.17) | 54 379 | 57 259 | 55 270 | 54 485 | 54 256 |
+| 76 | swift (5.2)| [kitura](https://kitura.io) (2.9) | 53 781 | 53 024 | 53 918 | 54 038 | 54 380 |
+| 77 | clojure (1.1)| [coast](https://coastonclojure.com) (1.0) | 53 658 | 54 906 | 54 811 | 54 441 | 54 569 |
+| 78 | swift (5.2)| [kitura-nio](https://kitura.io) (2.9) | 51 557 | 52 238 | 52 760 | 51 125 | 48 941 |
+| 79 | javascript (13.13)| [nestjs-fastify](https://nestjs.com) (7.0) | 50 927 | 61 518 | 61 342 | 59 838 | 59 286 |
+| 80 | scala (2.12)| [http4s](https://http4s.org) (0.21) | 50 456 | 55 733 | 53 409 | 51 699 | 51 000 |
+| 81 | javascript (13.13)| [moleculer](https://moleculer.services) (0.14) | 49 516 | 51 223 | 49 902 | 49 469 | 48 396 |
+| 82 | python (3.8)| [pyramid](https://trypyramid.com) (1.1) | 48 909 | 50 904 | 50 712 | 50 105 | 50 071 |
+| 83 | python (3.8)| [blacksheep](https://github.com/RobertoPrevato/BlackSheep) (0.2) | 48 515 | 53 995 | 53 945 | 52 060 | 51 654 |
+| 84 | php (7.4)| [imi](https://imiphp.com) (1.2) | 46 313 | 48 531 | 48 848 | 48 480 | 48 351 |
+| 85 | cpp (11)| [evhtp](https://criticalstack.com) (1.2) | 46 255 | 46 190 | 46 451 | 46 188 | 45 423 |
+| 86 | python (3.8)| [asgineer](https://asgineer.readthedocs.io) (0.7) | 45 651 | 53 218 | 52 878 | 50 745 | 50 842 |
+| 87 | python (3.8)| [hug](https://hug.rest) (2.6) | 43 027 | 47 883 | 44 284 | 47 203 | 47 202 |
+| 88 | rust (1.43)| [gotham](https://gotham.rs) (0.4) | 42 003 | 49 232 | 51 086 | 53 137 | 53 799 |
+| 89 | javascript (13.13)| [hapi](https://hapijs.com) (19.1) | 41 161 | 43 888 | 42 957 | 43 295 | 42 621 |
+| 90 | python (3.8)| [starlette](https://starlette.io) (0.13) | 40 929 | 43 577 | 43 163 | 41 701 | 41 667 |
+| 91 | javascript (13.13)| [restify](https://restify.com) (8.5) | 40 511 | 40 931 | 41 042 | 40 909 | 41 523 |
+| 92 | ruby (2.7)| [syro](https://github.com/soveran/syro) (3.2) | 39 558 | 40 617 | 38 735 | 38 463 | 38 254 |
+| 93 | ruby (2.7)| [hanami-api](https://hanamirb.org) (0.1) | 39 551 | 39 491 | 38 212 | 37 694 | 38 356 |
+| 94 | php (7.4)| [sw-fw-less](https://github.com/luoxiaojun1992/sw-fw-less) (preview) | 39 237 | 41 355 | 41 171 | 40 707 | 40 811 |
+| 95 | fsharp (4.7)| [suave](https://suave.io) (2.5) | 39 055 | 37 003 | 37 839 | 38 789 | 38 839 |
+| 96 | javascript (13.13)| [nestjs-express](https://nestjs.com) (7.0) | 38 952 | 40 161 | 39 781 | 39 481 | 39 660 |
+| 97 | python (3.8)| [emmett](https://github.com/emmett-framework/emmett) (2.0.0b2) | 36 507 | 40 939 | 40 503 | 38 905 | 38 914 |
+| 98 | ruby (2.7)| [roda](https://roda.jeremyevans.net) (3.31) | 36 252 | 37 274 | 35 806 | 35 756 | 35 667 |
+| 99 | php (7.4)| [swoft](https://swoft.org) (2.0) | 34 963 | 36 406 | 36 254 | 35 849 | 35 769 |
+| 100 | elixir (1.1)| [cowboy](https://ninenines.eu/docs/en/cowboy/2.7/guide/) (2.7) | 34 101 | 36 841 | 37 073 | 34 857 | 35 075 |
+| 101 | ruby (2.7)| [cuba](https://cuba.is) (3.9) | 33 547 | 33 462 | 32 412 | 32 126 | 32 387 |
+| 102 | elixir (1.1)| [plug](https://hexdocs.pm/plug) (1.10) | 31 764 | 33 073 | 30 731 | 30 071 | 31 487 |
+| 103 | dart (2.7)| [aqueduct](https://aqueduct.io) (3.3) | 30 643 | 29 819 | 30 617 | 30 179 | 29 956 |
+| 104 | crystal (0.34)| [shivneri](https://github.com/ujjwalguptaofficial/shivneri) (0.15) | 29 714 | 26 613 | 23 650 | 22 070 | 21 090 |
+| 105 | python (3.8)| [fastapi](https://fastapi.tiangolo.com) (0.54) | 29 526 | 30 750 | 30 447 | 29 334 | 29 323 |
+| 106 | python (3.8)| [responder](https://python-responder.org) (2.0) | 28 719 | 30 824 | 30 555 | 29 513 | 29 537 |
+| 107 | ruby (2.7)| [rack-routing](https://github.com/georgeu2000/rack-routing) (0.0) | 28 178 | 27 660 | 27 005 | 27 284 | 27 258 |
+| 108 | elixir (1.1)| [phoenix](https://phoenixframework.org) (1.5) | 27 785 | 28 497 | 27 997 | 27 894 | 27 739 |
+| 109 | ruby (2.7)| [rack_app](https://rack-app.com) (7.6) | 25 861 | 25 758 | 24 662 | 25 474 | 25 617 |
+| 110 | python (3.8)| [aiohttp](https://aiohttp.readthedocs.io) (3.6) | 25 410 | 27 605 | 27 415 | 26 806 | 26 701 |
+| 111 | python (3.8)| [clastic](https://github.com/mahmoud/clastic) (19.9) | 25 176 | 24 547 | 25 366 | 25 086 | 25 161 |
+| 112 | ruby (2.7)| [camping](https://github.com/camping/camping) (2.1) | 25 128 | 24 630 | 24 082 | 24 074 | 24 246 |
+| 113 | python (3.8)| [molten](https://moltenframework.com) (1.0) | 24 624 | 25 184 | 24 946 | 24 504 | 24 414 |
+| 114 | rust (1.43)| [iron](https://ironframework.io) (0.6) | 23 920 | 23 934 | 23 871 | 24 061 | 23 887 |
+| 115 | python (3.8)| [masonite](https://masoniteproject.com) (2.3) | 23 760 | 23 009 | 23 940 | 23 821 | 22 845 |
+| 116 | python (3.8)| [flask](https://flask.pocoo.org) (1.1) | 23 281 | 23 696 | 23 503 | 23 095 | 23 124 |
+| 117 | javascript (13.13)| [turbo_polka](https://github.com/mafintosh/turbo-http) (0.3) | 23 012 | 21 980 | 20 609 | 20 503 | 20 523 |
+| 118 | python (3.8)| [sanic](https://github.com/huge-success/sanic) (19.12) | 18 945 | 18 499 | 18 378 | 18 030 | 17 874 |
+| 119 | php (7.4)| [spiral](https://github.com/spiral/framework) (2.4) | 18 094 | 18 359 | 18 493 | 18 315 | 18 334 |
+| 120 | ruby (2.7)| [sinatra](https://sinatrarb.com) (2.0) | 15 748 | 15 559 | 15 530 | 15 499 | 15 564 |
+| 121 | ruby (2.7)| [grape](https://ruby-grape.org) (1.3) | 14 561 | 14 090 | 14 347 | 14 291 | 14 259 |
+| 122 | javascript (13.13)| [sails](https://sailsjs.com) (1.2) | 13 036 | 13 560 | 13 417 | 13 291 | 12 804 |
+| 123 | python (3.8)| [quart](https://pgjones.gitlab.io/quart) (0.11) | 12 156 | 12 009 | 11 259 | 10 752 | 10 708 |
+| 124 | ruby (2.7)| [flame](https://github.com/AlexWayfer/flame) (4.18) | 11 476 | 11 249 | 11 219 | 11 130 | 11 119 |
+| 125 | go (1.14)| [tango](https://gitea.com/lunny/tango) (0.6) | 11 462 | 11 746 | 11 757 | 11 759 | 7 890 |
+| 126 | ruby (2.7)| [hanami](https://hanamirb.org) (1.3) | 10 672 | 10 561 | 10 626 | 10 565 | 10 577 |
+| 127 | go (1.14)| [gramework](https://github.com/gramework/gramework) (1.7) | 9 878 | 14 850 | 15 024 | 10 725 | 10 026 |
+| 128 | swift (5.2)| [swifter](https://github.com/httpswift/swifter) (1.4) | 9 830 | 10 600 | 10 903 | 11 109 | 10 246 |
+| 129 | php (7.4)| [ubiquity](https://ubiquity.kobject.net) (2.3) | 9 197 | 9 153 | 8 958 | 51 470 | 49 640 |
+| 130 | python (3.8)| [django](https://djangoproject.com) (3.0) | 8 999 | 9 892 | 9 320 | 9 660 | 9 672 |
+| 131 | python (3.8)| [cherrypy](https://github.com/cherrypy/cherrypy) (18.6) | 8 023 | 9 119 | 9 042 | 9 014 | 9 059 |
+| 132 | php (7.4)| [one-fpm](https://github.com/lizhichao/one) (2.0) | 7 868 | 7 843 | 7 702 | 42 570 | 40 132 |
+| 133 | php (7.4)| [phalcon](https://phalcon.io) (4.0) | 7 519 | 7 549 | 7 599 | 49 776 | 48 515 |
+| 134 | php (7.4)| [hamlet](https://github.com/vasily-kartashov/hamlet-core) (3.2) | 7 499 | 7 441 | 7 403 | 42 504 | 41 696 |
+| 135 | python (3.8)| [tornado](https://tornadoweb.org) (6.0) | 7 173 | 8 431 | 8 263 | 8 287 | 8 296 |
+| 136 | php (7.4)| [ice](https://iceframework.org) (1.5) | 6 300 | 6 190 | 6 211 | 50 405 | 47 794 |
+| 137 | php (7.4)| [chubbyphp](https://github.com/chubbyphp/chubbyphp-framework) (2.8) | 5 596 | 5 571 | 5 689 | 42 996 | 39 791 |
+| 138 | crystal (0.34)| [onyx](https://onyxframework.org) (0.5) | 4 971 | 5 090 | 5 085 | 5 150 | 5 077 |
+| 139 | php (7.4)| [slim](https://slimframework.com) (4.5) | 4 604 | 4 626 | 4 689 | 42 778 | 39 698 |
+| 140 | php (7.4)| [lumen](https://lumen.laravel.com) (7.0) | 4 332 | 4 354 | 4 384 | 42 445 | 40 180 |
+| 141 | pony (0.33)| [jennet](https://github.com/Theodus/jennet) (0.1) | 4 209 | 8 526 | 9 105 | 8 433 | 8 492 |
+| 142 | php (7.4)| [yii](https://yiiframework.com) (2.0) | 4 109 | 4 072 | 4 246 | 42 297 | 39 011 |
+| 143 | ruby (2.7)| [rails](https://rubyonrails.org) (6.0) | 3 868 | 3 640 | 3 616 | 3 370 | 3 544 |
+| 144 | php (7.4)| [symfony](https://symfony.com) (4.3) | 3 156 | 3 160 | 3 210 | 41 378 | 39 513 |
+| 145 | php (7.4)| [mezzio](https://docs.mezzio.dev) (3.2) | 2 825 | 2 837 | 2 907 | 41 157 | 38 802 |
+| 146 | julia (1.4)| [merly](https://github.com/codeneomatrix/Merly.jl) (0.2) | 2 693 | 8 069 | 6 593 | 5 045 | 3 043 |
+| 147 | python (3.8)| [cyclone](https://cyclone.io) (1.3) | 2 388 | 2 409 | 2 377 | 2 387 | 2 377 |
+| 148 | python (3.8)| [klein](https://github.com/twisted/klein) (19.6) | 1 603 | 1 624 | 1 600 | 1 591 | 1 584 |
+| 149 | python (3.8)| [nameko](https://github.com/nameko/nameko) (2.12) | 1 542 | 1 504 | 1 495 | 1 462 | 1 463 |
+| 150 | php (7.4)| [laminas](https://getlaminas.org) (3.1) | 1 424 | 1 459 | 1 486 | 38 302 | 36 166 |
+| 151 | perl (5.3)| [dancer2](https://perldancer.org) (2.0) | 874 | 1 425 | 1 555 | 1 252 | 604 |
+| 152 | php (7.4)| [laravel](https://laravel.com) (7.7) | 823 | 158 | 2 250 | 23 612 | 21 491 |
+| 153 | php (7.4)| [basicphp](https://github.com/ray-ang/basicphp) (0.9) | 568 | 463 | 1 528 | 33 202 | 33 380 |
 
 ## How to contribute ?
 

--- a/README.mustache.md
+++ b/README.mustache.md
@@ -31,13 +31,17 @@ This project aims to be a load benchmarking suite, no more, no less
 + [wrk](https://github.com/wg/wrk) as benchmarking tool, `>= 4.1.0`
 + [postgresql](https://www.postgresql.org) to store data, `>= 10`
 
-:information_source: you need `wrk` **stable**
+:information_source::information_source::information_source::information_source::information_source:
 
-~~~sh
-git clone --branch 4.1.0 https://github.com/wg/wrk
+:warning: On `OSX` you need `docker-machine` to use `docker` containerization
+
+~~~
+brew install docker-machine
+docker-machine create default
+eval $(docker-machine env default)
 ~~~
 
-:warning: `docker` is used for **development** purpose, `production` results will be computed on [DigitalOcean](https://www.digitalocean.com) :warning:
+:information_source::information_source::information_source::information_source::information_source:
 
 ## Usage
 

--- a/README.mustache.md
+++ b/README.mustache.md
@@ -111,7 +111,7 @@ bin/db to_readme
 
 :information_source:  Updated on **{{date}}** :information_source:
 
-> Benchmarking with [wrk](https://github.com/ioquatix/wrk)
+> Benchmarking with [wrk](https://github.com/wg/wrk)
    + Threads : 8
    + Timeout : 8
    + Duration : 15s (seconds)

--- a/README.mustache.md
+++ b/README.mustache.md
@@ -109,6 +109,12 @@ bin/db to_readme
 
 ## Results
 
+:warning::warning::warning::warning:
+
+[Vapor](https://vapor.codes) is hidden due, see https://github.com/the-benchmarker/web-frameworks/issues/2575
+
+:warning::warning::warning::warning:
+
 :information_source:  Updated on **{{date}}** :information_source:
 
 > Benchmarking with [wrk](https://github.com/wg/wrk)

--- a/java/jooby/pom.xml
+++ b/java/jooby/pom.xml
@@ -35,10 +35,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-<<<<<<< Updated upstream
-=======
-        <version>[3.0,4.0)</version>
->>>>>>> Stashed changes
         <executions>
           <execution>
             <id>uber-jar</id>

--- a/java/jooby/pom.xml
+++ b/java/jooby/pom.xml
@@ -15,7 +15,7 @@
     <!-- Startup class -->
     <application.class>benchmark.App</application.class>
 
-    <jooby.version>2.8.1</jooby.version>
+    <jooby.version>[2.8,2.9)</jooby.version>
 
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -35,6 +35,10 @@
     <plugins>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
+<<<<<<< Updated upstream
+=======
+        <version>[3.0,4.0)</version>
+>>>>>>> Stashed changes
         <executions>
           <execution>
             <id>uber-jar</id>

--- a/nim/httpbeast/config.yaml
+++ b/nim/httpbeast/config.yaml
@@ -1,4 +1,4 @@
 framework:
   github: dom96/httpbeast
-  version: 2.2
+  version: 0.2
   

--- a/spec/benchmark_spec.cr
+++ b/spec/benchmark_spec.cr
@@ -7,7 +7,7 @@ def get_ip(name)
   end
   infos = name.split(".")
   language = infos.shift
-  framework = infos.join(".") 
+  framework = infos.join(".")
   path = File.join(language, framework, "ip.txt")
   File.read(path).strip
 end

--- a/tools/src/client.cr
+++ b/tools/src/client.cr
@@ -27,7 +27,7 @@ class Client < Admiral::Command
   define_flag framework : String, description: "Framework used", required: true, long: "framework", short: "f"
   define_flag concurrencies : Array(Int32), description: "Concurrency level", required: true, long: "concurrency", short: "c"
   define_flag routes : Array(String), long: "routes", short: "r", default: ["GET:/"]
-  define_flag host : String, description: "Host and port instead ip.txt"
+  define_flag host : String, description: "Host", short: "h", required: true, long: "hostname"
 
   def run
     db = DB.open(ENV["DATABASE_URL"])
@@ -41,7 +41,7 @@ class Client < Admiral::Command
     framework_id = row.read(Int)
 
     sleep 25 # due to external program usage
-    address = flags.host ? flags.host : File.read("ip.txt").strip + ":3000"
+    address = "#{flags.host}:3000"
 
     # Run a 5-second primer at 8 client-concurrency to verify that the server is in fact running. These results are not captured.
 

--- a/tools/src/make.cr
+++ b/tools/src/make.cr
@@ -248,7 +248,10 @@ class App < Admiral::Command
                   yaml.scalar "docker build -t #{language}.#{name} . #{flags.docker_options}"
 
                   # Run container, and store IP
-                  yaml.scalar "docker run #{container_expose} -td #{language}.#{name} | xargs -i docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' {} > ip.txt"
+                  yaml.scalar "docker run #{container_expose} -td #{language}.#{name} > cid.txt"
+
+                  # Get container IP
+                  yaml.scalar "docker inspect `cat cid.txt` -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' > ip.txt"
 
                   # Launch sieging
                   unless flags.without_sieger


### PR DESCRIPTION
Hi,

This `PR` adds `OSX` support

:warning: If you are not using a **linux** `distro`, you **MUST** :
+ have `docker-machine` (:information_source: available via `brew` for `OSX`)
+ use `bin/make config --driver docker-machine`
+ create a docker machine `docker-machine create the-benchmarker`
+ has a `DOCKER_HOST` defined `eval $(docker-machine env default)`

This is not the main `development workflow`, then any help maintaining `OSX` is :heart: 

------------------
Closes #2587 