### PR TITLE
Disable renovate for javascript, php, elixir

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,17 @@
 {
-  "extends": [
-    "config:base",
-    ":preserveSemverRanges"
+  "extends": ["config:base", ":preserveSemverRanges"],
+  "packageRules": [
+    {
+      "languages": ["elixir"],
+      "enabled": false
+    },
+    {
+      "languages": ["php"],
+      "enabled": false
+    },
+    {
+      "languages": ["javascript"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
Hi,

This  `PR` disable `renovate` for :

+ [x] php
+ [x] javascript
+ [x] elixir

The idea is that `dependabot` is working well enough for those languages.

-------------------------------
Closes #2553 #2570 #2610 