### PR TITLE
[JVM] Use LTS version

### DIFF
--- a/clojure/Dockerfile
+++ b/clojure/Dockerfile
@@ -1,25 +1,21 @@
-FROM clojure:openjdk-14-tools-deps-1.10.1.478-alpine
+FROM clojure:openjdk-11-tools-deps-slim-buster
 
 WORKDIR /usr/src/app
 
 COPY . ./
 
-{{#build_deps}}
-  RUN apk add {{{.}}}
-{{/build_deps}}
-
 RUN clojure -Auberjar
 
-FROM openjdk:14-alpine
+FROM openjdk:11-jre-slim-buster
 
 WORKDIR /opt/bin
 
 {{#environment}}
-ENV {{{.}}}
+  ENV {{{.}}}
 {{/environment}}
 
 {{#files}}
-COPY --from=0 /usr/src/app/{{{.}}} /opt/bin/{{{.}}} 
+  COPY --from=0 /usr/src/app/{{{.}}} /opt/bin/{{{.}}} 
 {{/files}}
 
 {{#command}}

--- a/clojure/coast/config.yaml
+++ b/clojure/coast/config.yaml
@@ -5,9 +5,6 @@ framework:
 environment:
   COAST_ENV: prod
 
-build_deps:
-  - bash
-  
 files:
   - coast.jar
 

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -23,7 +23,7 @@ COPY . ./
 {{/build}}
 
 
-FROM openjdk:8-alpine
+FROM openjdk:8-jre-alpine
 
 {{#bin_deps}}
   RUN apk add {{{.}}}

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:6.3-jdk8
+FROM gradle:jdk11
 
 WORKDIR /usr/src/app
 
@@ -10,7 +10,7 @@ COPY . ./
 
 RUN gradle build
 
-FROM openjdk:8-alpine
+FROM openjdk:11-jre-slim
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Hi,

This `PR` modify the default version for `jv` based frameworks :

+ [x] `clojure` => **11**
+ [x] `kotlin` => **11**
+ [x] `scala` => **11**
+ [x] `java` => **8** (since `act` use **8**, it is more accurate to use **8** for all `java` frameworks)

Regards,

---------
Closes #2638