### PR TITLE
[Pony] Use static compilation

### DIFF
--- a/pony/Dockerfile
+++ b/pony/Dockerfile
@@ -1,7 +1,6 @@
 FROM ponylang/ponyc:0.35.1
 
-RUN apt-get update
-RUN apt-get install -y clang libssl-dev
+RUN apt-get -y update && apt-get -y install clang libssl-dev
 
 WORKDIR /src/main
 
@@ -20,7 +19,9 @@ COPY . ./
 
 RUN stable env ponyc -Dopenssl_1.1.x -Dstatic
 
-FROM alpine
+FROM ubuntu
+
+RUN apt-get -y update && apt-get -y install openssl libatomic1
 
 WORKDIR /opt
 

--- a/pony/Dockerfile
+++ b/pony/Dockerfile
@@ -18,13 +18,12 @@ COPY . ./
   RUN {{{.}}}
 {{/before_command}}
 
-RUN stable env ponyc -Dopenssl_1.1.x
+RUN stable env ponyc -Dopenssl_1.1.x -Dstatic
 
-{{#command}}
-  CMD {{{.}}}
-{{/command}}
+FROM alpine
 
-{{^command}}
-  CMD ./main
-{{/command}}
+WORKDIR /opt
 
+COPY --from=0 /src/main/main main
+
+CMD ./main


### PR DESCRIPTION
Hi,

It convenient for maintenance tasks that `pony` compiles in one single binary.

It avoid having to setup third-party dependencies.

Regards,