### PR TITLE
Downgrade muuntaja to v0.6.6

### DIFF
--- a/clojure/luminus/project.clj
+++ b/clojure/luminus/project.clj
@@ -10,7 +10,7 @@
                  [luminus-transit "0.1.2"]
                  [luminus/ring-ttl-session "0.3.3"]
                  [markdown-clj "1.10.4"]
-                 [metosin/muuntaja "0.6.7"]
+                 [metosin/muuntaja "0.6.6"]
                  [metosin/reitit "0.4.2"]
                  [metosin/ring-http-response "0.9.1"]
                  [mount "0.1.16"]


### PR DESCRIPTION
Hi,

This `PR` reverts #2654

With `muuntaja` `0.6.7`, I have a 

~~~java
Syntax error compiling new at (jsonista/core.clj:131:23).
Syntax error (ClassNotFoundException) compiling new at (jsonista/core.clj:131:23).
com.fasterxml.jackson.databind.ser.std.ToStringSerializerBase
~~~

/cc @yogthos

Regards,