### PR TITLE
Fix macos

### DIFF
--- a/tools/src/client.cr
+++ b/tools/src/client.cr
@@ -40,7 +40,6 @@ class Client < Admiral::Command
     row.move_next
     framework_id = row.read(Int)
 
-    sleep 25 # due to external program usage
     address = "#{flags.host}:3000"
 
     # Run a 5-second primer at 8 client-concurrency to verify that the server is in fact running. These results are not captured.
@@ -58,6 +57,7 @@ class Client < Admiral::Command
       url = "http://#{address}#{uri}"
 
       flags.concurrencies.each do |concurrency|
+        puts "Start @ #{concurrency}"
         row = db.query("INSERT INTO concurrencies (level) VALUES ($1) ON CONFLICT (level) DO UPDATE SET level = $1 RETURNING id", concurrency)
         row.move_next
         concurrency_level_id = row.read(Int)
@@ -105,6 +105,7 @@ class Client < Admiral::Command
         # insert(framework_id, "percentile_ninety", result[14])
         # insert(framework_id, "percentile_ninety_nine", result[15])
         # insert(framework_id, "percentile_ninety_nine_ninety", result[16])
+        puts "End @ #{concurrency}"
       end
     end
 

--- a/tools/src/db.cr
+++ b/tools/src/db.cr
@@ -89,7 +89,7 @@ class App < Admiral::Command
         rank1[concurrencies.first].to_f <=> rank0[concurrencies.first].to_f
       end
       sorted.each do |row|
-        lines << "| %s (%s)| [%s](%s) (%s) | %s | %s | %s | %s | %s |" % [
+        lines << "| %s (%s)| [%s](%s) (%s) | %s | %s | %s |"  % [
           c,
           row["language"],
           row["language_version"],

--- a/tools/src/db.cr
+++ b/tools/src/db.cr
@@ -81,8 +81,8 @@ class App < Admiral::Command
       end
 
       lines = [
-        "|    | Language | Framework | Speed (%s) | Speed (%s) | Speed (%s) | Speed (%s) |" % [concurrencies[0], concurrencies[1], concurrencies[2], concurrencies[3]],
-        "|----|----------|-----------|-----------:|------------:|------------:|-------------:|",
+        "|    | Language | Framework | Speed (%s) | Speed (%s) | Speed (%s) |" % [concurrencies[0], concurrencies[1], concurrencies[2]],
+        "|----|----------|-----------|-----------:|------------:|----------:|",
       ]
       c = 1
       sorted = frameworks.values.sort do |rank0, rank1|
@@ -99,7 +99,6 @@ class App < Admiral::Command
           row[concurrencies[0]].to_f.trunc.format(delimiter: ' ', decimal_places: 0),
           row[concurrencies[1]].to_f.trunc.format(delimiter: ' ', decimal_places: 0),
           row[concurrencies[2]].to_f.trunc.format(delimiter: ' ', decimal_places: 0),
-          row[concurrencies[3]].to_f.trunc.format(delimiter: ' ', decimal_places: 0),
         ]
         c += 1
       end

--- a/tools/src/db.cr
+++ b/tools/src/db.cr
@@ -25,7 +25,7 @@ class App < Admiral::Command
     def run
       factor = System.cpu_count**2
       concurrencies = [] of String
-      [1, 4, 8, 16, 32].each do |i|
+      [1, 4, 8, 16].each do |i|
         concurrencies << "concurrency_#{factor*i}"
       end
 
@@ -81,15 +81,15 @@ class App < Admiral::Command
       end
 
       lines = [
-        "|    | Language | Framework | Speed (64) | Speed (256) | Speed (512) | Speed (1024) |  Speed (2048) |",
-        "|----|----------|-----------|-----------:|------------:|------------:|-------------:|--------------:|",
+        "|    | Language | Framework | Speed (%s) | Speed (%s) | Speed (%s) | Speed (%s) |" % [concurrencies[0], concurrencies[1], concurrencies[2], concurrencies[3]],
+        "|----|----------|-----------|-----------:|------------:|------------:|-------------:|",
       ]
       c = 1
       sorted = frameworks.values.sort do |rank0, rank1|
         rank1[concurrencies.first].to_f <=> rank0[concurrencies.first].to_f
       end
       sorted.each do |row|
-        lines << "| %s | %s (%s)| [%s](%s) (%s) | %s | %s | %s | %s | %s |" % [
+        lines << "| %s (%s)| [%s](%s) (%s) | %s | %s | %s | %s | %s |" % [
           c,
           row["language"],
           row["language_version"],
@@ -100,7 +100,6 @@ class App < Admiral::Command
           row[concurrencies[1]].to_f.trunc.format(delimiter: ' ', decimal_places: 0),
           row[concurrencies[2]].to_f.trunc.format(delimiter: ' ', decimal_places: 0),
           row[concurrencies[3]].to_f.trunc.format(delimiter: ' ', decimal_places: 0),
-          row[concurrencies[4]].to_f.trunc.format(delimiter: ' ', decimal_places: 0),
         ]
         c += 1
       end

--- a/tools/src/make.cr
+++ b/tools/src/make.cr
@@ -249,9 +249,11 @@ class App < Admiral::Command
                   when "docker"
                     yaml.scalar "docker run -td #{language}.#{name} > cid.txt"
                     yaml.scalar "docker inspect `cat cid.txt` -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' > ip.txt"
+                    yaml.scalar "sleep 5"
                   when "docker-machine"
                     yaml.scalar "docker run -p 3000:3000 -d #{language}.#{name}"
                     yaml.scalar "docker-machine ip default > ip.txt"
+                    yaml.scalar "sleep 5"
                   else
                     raise "unsupported provider"
                   end
@@ -260,7 +262,7 @@ class App < Admiral::Command
                   unless flags.without_sieger
                     factor = System.cpu_count**2
                     command = "../../bin/client --language #{language} --framework #{name} -r GET:/ -r GET:/user/0 -r POST:/user -h `cat ip.txt`"
-                    [1, 4, 8, 16, 32].each do |i|
+                    [1, 4, 8, 16].each do |i|
                       command += " -c #{factor*i} "
                     end
 

--- a/tools/src/make.cr
+++ b/tools/src/make.cr
@@ -262,7 +262,7 @@ class App < Admiral::Command
                   unless flags.without_sieger
                     factor = System.cpu_count**2
                     command = "../../bin/client --language #{language} --framework #{name} -r GET:/ -r GET:/user/0 -r POST:/user -h `cat ip.txt`"
-                    [1, 4, 8, 16].each do |i|
+                    [1, 4, 8].each do |i|
                       command += " -c #{factor*i} "
                     end
 


### PR DESCRIPTION
Hi,

When using `docker-machine` (on `mac os`), using a **concurrency** higher (or equal) that **1024**, something is wrong.

Because of the next version (in `cloud`) use **100** (randomly choosen), a quick-fix consist of decreasing concurrency level.

Regards,