### PR TITLE
[Go] Remove extra flags for kami

### DIFF
--- a/go/kami/go.mod
+++ b/go/kami/go.mod
@@ -1,8 +1,3 @@
 module main
 
-require (
-	github.com/dimfeld/httptreemux v5.0.1+incompatible // indirect
-	github.com/guregu/kami v2.2.1+incompatible
-	github.com/zenazn/goji v0.9.0 // indirect
-	golang.org/x/net v0.0.0-20190301231341-16b79f2e4e95 // indirect
-)
+require github.com/guregu/kami v2.2.1


### PR DESCRIPTION
Hi @guregu,

As I understand https://github.com/renovatebot/renovate/issues/4586#issue-503006804 `// indirect` flags could not be updated `here`.

Moreover, having `+incompatible` appears not to be necessary.

Regards,

PS : Can I make you codeowner of `kami` here ? As this you will be pinged on each update