### PR TITLE
[Go] Remove incompatible flag fo chi

### DIFF
--- a/go/chi/go.mod
+++ b/go/chi/go.mod
@@ -1,3 +1,3 @@
 module main
 
-require github.com/go-chi/chi v4.1.1+incompatible
+require github.com/go-chi/chi v4.1.1


### PR DESCRIPTION
Hi @pkieltyka,

This `PR` remove `+incompatible` flag for `chi`.

Seems to work without.

What is the impact @appleboy ?

Regards,