### PR TITLE
[Python] Use rust nightly to compile maturin

### DIFF
--- a/python/apidaora/config.yaml
+++ b/python/apidaora/config.yaml
@@ -7,12 +7,11 @@ build_deps:
   - curl
   - openssl-dev
 
-# install maturin to build orjson
-# @see https://github.com/ijl/orjson/issues/8#issuecomment-570335365
 fixes:
   - curl https://sh.rustup.rs > init.sh
   - sh init.sh -y
   - find $HOME/.cargo/bin -type f -exec install {} /usr/local/bin \;
+  - rustup default nightly
 
 environment:
   RUSTFLAGS: -C target-feature=-crt-static


### PR DESCRIPTION
Hi @dutradda,

`apidaora` is failing `here`.

It appear that `maturin` require `rust` **nighlty**
https://github.com/racer-rust/racer/issues/1023 

Regards,