### PR TITLE
[Nim] Upgrade to 1.2.2

### DIFF
--- a/nim/Dockerfile
+++ b/nim/Dockerfile
@@ -1,4 +1,4 @@
-FROM nimlang/nim:1.2.0-alpine
+FROM nimlang/nim:1.2.2-alpine
 
 WORKDIR /usr/src/app
 
@@ -21,5 +21,7 @@ RUN nimble c \
         -y server.nim
 
 FROM alpine
+
 COPY --from=0 /usr/src/app/server /usr/src/app/server
+
 CMD /usr/src/app/server


### PR DESCRIPTION
Hi,

As tag `1.2.2` is created in https://github.com/moigagoo/nimage, it will be shortly available in **docker hub** => https://hub.docker.com/r/nimlang/nim

Regards,

/cc @Willyboar 