### PR TITLE
Hard-code concurrency levels

### DIFF
--- a/tools/src/make.cr
+++ b/tools/src/make.cr
@@ -260,13 +260,7 @@ class App < Admiral::Command
 
                   # Launch sieging
                   unless flags.without_sieger
-                    factor = System.cpu_count**2
-                    command = "../../bin/client --language #{language} --framework #{name} -r GET:/ -r GET:/user/0 -r POST:/user -h `cat ip.txt`"
-                    [1, 4, 8].each do |i|
-                      command += " -c #{factor*i} "
-                    end
-
-                    yaml.scalar command
+                    yaml.scalar '../../bin/client --language #{language} --framework #{name} -r GET:/ -r GET:/user/0 -r POST:/user -h `cat ip.txt` -c 64 -c 256 -c 512'
                   end
 
                   # Drop the container


### PR DESCRIPTION
Hi @i4004,

Thanks for opening the issue #3028

The issue raised was due to a dynamic concurrency level selection. 

As I'm working on a 8 CPU, I have not the problem, but it seems that you have 12 CPU.

There is no need of a dynamic selection of currency levels, so I hard code it.

Let me know if this fix your bug

---
Closes  #3028