### PR TITLE
[Java] Remove maven plugin version

### DIFF
--- a/java/light-4j/pom.xml
+++ b/java/light-4j/pom.xml
@@ -204,17 +204,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
-                    
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -235,7 +232,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-shade-plugin</artifactId>
-                        <version>2.4.3</version>
                         <executions>
                             <execution>
                                 <phase>package</phase>
@@ -264,7 +260,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -277,7 +272,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.4</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -290,7 +284,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.4.0</version>
                         <configuration>
                             <executable>java</executable>
                             <arguments>
@@ -316,7 +309,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.4.0</version>
                         <configuration>
                             <workingDirectory>${project.build.directory}</workingDirectory>
                             <executable>java</executable>


### PR DESCRIPTION
Hi,

This `PR` removes (maven) plugin versions for java frameworks

+ [x] act
+ [x] blade
+ [x] javalin
+ [x] jooby
+ [x] light-4j
+ [x] micronaut
+ [x] rapidoid
+ [x] spring-boot
+ [x] spring-framework
+ [x] struts2

@tsuilouis @stevehu Is there any warning using this ?

Regards,