### PR TITLE
[Java] Update light4j to 2.0

### DIFF
--- a/java/light-4j/config.yaml
+++ b/java/light-4j/config.yaml
@@ -1,6 +1,6 @@
 framework:
   website: doc.networknt.com
-  version: 1.6
+  version: 2.0
 
 build:
   - mvn clean package -Prelease

--- a/java/light-4j/pom.xml
+++ b/java/light-4j/pom.xml
@@ -8,11 +8,11 @@
     <version>0.0.1</version>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.main.class>com.networknt.server.Server</project.main.class>
-        <version.light-4j>[1.6,1.7)</version.light-4j>
+        <version.light-4j>[2.0,2.1)</version.light-4j>
         <version.jackson>[2.0.0,3.0.0-SNAPSHOT)</version.jackson>
         <version.undertow>2.0.29.Final</version.undertow>
         <version.json-schema-validator>[1.0.29,)</version.json-schema-validator>
@@ -205,8 +205,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Hi @stevehu @tsuilouis,

This `PR` update https://github.com/networknt/light-4j to **2.0**

As I notice we have to compile targeted VM, right ?

Regards,