### PR TITLE
[Python] Disable logging

### DIFF
--- a/python/aiohttp/server.py
+++ b/python/aiohttp/server.py
@@ -1,3 +1,9 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
+
 from aiohttp import web
 
 routes = web.RouteTableDef()

--- a/python/apidaora/server.py
+++ b/python/apidaora/server.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 from apidaora.asgi.router import Route, make_router
 from apidaora.asgi.app import asgi_app
 from apidaora.method import MethodType

--- a/python/asgineer/server.py
+++ b/python/asgineer/server.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 import asgineer
 
 

--- a/python/blacksheep/server.py
+++ b/python/blacksheep/server.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 from blacksheep.server import Application
 from blacksheep.server.responses import text
 

--- a/python/bottle/server.py
+++ b/python/bottle/server.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 from bottle import Bottle
 from meinheld import patch
 

--- a/python/cherrypy/server.py
+++ b/python/cherrypy/server.py
@@ -1,4 +1,8 @@
 #! /usr/bin/env python3
+# Disable all logging features
+import logging
+
+logging.disable()
 import cherrypy
 
 

--- a/python/clastic/server.py
+++ b/python/clastic/server.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 from clastic import Application, render_basic
 
 

--- a/python/cyclone/server.py
+++ b/python/cyclone/server.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 import cyclone.web
 from twisted.application import internet
 from twisted.application import service

--- a/python/django/app/wsgi.py
+++ b/python/django/app/wsgi.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 """
 WSGI config for bl project.
 

--- a/python/emmett/server.py
+++ b/python/emmett/server.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 from emmett import App
 
 app = App(__name__)

--- a/python/falcon/server.py
+++ b/python/falcon/server.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 import falcon
 from meinheld import patch
 

--- a/python/fastapi/server.py
+++ b/python/fastapi/server.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 from fastapi import FastAPI
 from starlette.responses import PlainTextResponse
 

--- a/python/flask/server.py
+++ b/python/flask/server.py
@@ -1,3 +1,9 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
+
 from flask import Flask
 from meinheld import patch
 

--- a/python/hug/server.py
+++ b/python/hug/server.py
@@ -1,3 +1,9 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
+
 import hug
 from meinheld import patch
 

--- a/python/klein/server.py
+++ b/python/klein/server.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 from klein import Klein
 
 app = Klein()

--- a/python/masonite/wsgi.py
+++ b/python/masonite/wsgi.py
@@ -1,3 +1,9 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
+
 """First Entry For The WSGI Server."""
 
 from masonite.app import App

--- a/python/molten/server.py
+++ b/python/molten/server.py
@@ -1,3 +1,9 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
+
 from molten import App, Route, HTTP_200, Response
 
 

--- a/python/nameko/server.py
+++ b/python/nameko/server.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 from nameko.web.handlers import http
 
 

--- a/python/pyramid/server.py
+++ b/python/pyramid/server.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 from pyramid.config import Configurator
 from pyramid.response import Response
 

--- a/python/quart/server.py
+++ b/python/quart/server.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 from quart import Quart
 
 app = Quart(__name__)

--- a/python/responder/server.py
+++ b/python/responder/server.py
@@ -1,3 +1,8 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 import responder
 
 app = responder.API()

--- a/python/sanic/server.py
+++ b/python/sanic/server.py
@@ -1,57 +1,15 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
 import multiprocessing
 
 from sanic import Sanic
 from sanic.response import text
 
-LOGGING_CONFIG = dict(
-    version=1,
-    disable_existing_loggers=False,
-    loggers={
-        "sanic.root": {"level": "WARNING", "handlers": ["console"]},
-        "sanic.error": {
-            "level": "WARNING",
-            "handlers": ["error_console"],
-            "propagate": True,
-            "qualname": "sanic.error",
-        },
-        "sanic.access": {
-            "level": "WARNING",
-            "handlers": ["access_console"],
-            "propagate": True,
-            "qualname": "sanic.access",
-        },
-    },
-    handlers={
-        "console": {
-            "class": "logging.NullHandler",
-            "formatter": "generic",
-        },
-        "error_console": {
-            "class": "logging.NullHandler",
-            "formatter": "generic",
-        },
-        "access_console": {
-            "class": "logging.NullHandler",
-            "formatter": "access",
-        },
-    },
-    formatters={
-        "generic": {
-            "format": "%(asctime)s [%(process)d] [%(levelname)s] %(message)s",
-            "datefmt": "[%Y-%m-%d %H:%M:%S %z]",
-            "class": "logging.Formatter",
-        },
-        "access": {
-            "format": "%(asctime)s - (%(name)s)[%(levelname)s][%(host)s]: "
-            + "%(request)s %(message)s %(status)d %(byte)d",
-            "datefmt": "[%Y-%m-%d %H:%M:%S %z]",
-            "class": "logging.Formatter",
-        },
-    },
-)
 
-
-app = Sanic("benchmark", log_config=LOGGING_CONFIG)
+app = Sanic("benchmark")
 
 
 @app.route("/")
@@ -68,7 +26,7 @@ async def user_info(request, id):
 async def user(request):
     return text("")
 
+
 if __name__ == "__main__":
     workers = multiprocessing.cpu_count()
-    app.run(host='0.0.0.0', port=3000, workers=workers,
-            debug=False, access_log=False)
+    app.run(host="0.0.0.0", port=3000, workers=workers, debug=False, access_log=False)

--- a/python/starlette/server.py
+++ b/python/starlette/server.py
@@ -1,3 +1,9 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
+
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse
 

--- a/python/tonberry/server.py
+++ b/python/tonberry/server.py
@@ -1,3 +1,9 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
+
 from tonberry import create_app, expose
 from tonberry.content_types import TextPlain
 
@@ -14,5 +20,6 @@ class Root:
     @expose.get
     async def user(self, user_id: int) -> TextPlain:
         return user_id
+
 
 app = create_app(root=Root)

--- a/python/tornado/server.py
+++ b/python/tornado/server.py
@@ -1,3 +1,9 @@
+# Disable all logging features
+import logging
+
+logging.disable()
+
+
 import tornado.httpserver
 import tornado.ioloop
 import tornado.web


### PR DESCRIPTION
Hi,

This `PR` replace #3055. it **disable** logging for all `python` **frameworks**.

Logging is disabled for :

- [x] aiohttp
- [x] apidaora
- [x] asgineer
- [x] blacksheep
- [x] bottle
- [x] cherrypy
- [x] clastic
- [x] cyclone
- [x] django
- [x] emmett
- [x] falcon
- [x] fastapi
- [x] flask
- [x] hug
- [x] klein
- [x] masonite
- [x] molten
- [x] nameko
- [x] pyramid
- [x] quart
- [x] responder
- [x] sanic
- [x] starlette
- [x] tonberry
- [x] tornado

Regards,

/cc @pgjones @ahopkins @tiangolo @Ayehavgunne