### PR TITLE
[Javascript] Allow major upgrade for node

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,8 @@
 {
-  "extends": ["config:base", ":preserveSemverRanges"]
+  "extends": ["config:base", ":preserveSemverRanges"],
+  "node": {
+    "major": {
+      "enabled": true
+    }
+  }
 }


### PR DESCRIPTION
Hi,

By default `renovatebot` does **NOT** upgrade `node` **major**
@see https://github.com/renovatebot/config-help/issues/791

This `PR` override this.

Regards,