### PR TITLE
Fix Pakyow, tune performance

### DIFF
--- a/ruby/pakyow/Gemfile
+++ b/ruby/pakyow/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
 
-gem "pakyow", "~> 1.0.0"
 gem "pakyow-core", "~> 1.0.0"
 gem "pakyow-routing", "~> 1.0.0"

--- a/ruby/pakyow/config.yaml
+++ b/ruby/pakyow/config.yaml
@@ -2,4 +2,4 @@ framework:
   website: pakyow.com
   version: 1.0
 
-command: bundle exec pakyow boot -e production
+command: bundle exec pakyow boot -e ludicrous

--- a/ruby/pakyow/config.yaml
+++ b/ruby/pakyow/config.yaml
@@ -2,4 +2,4 @@ framework:
   website: pakyow.com
   version: 1.0
 
-command: bundle exec pakyow boot -e ludicrous
+command: bundle exec pakyow boot -e production


### PR DESCRIPTION
@waghanza This should fix the Pakyow issue that we discussed in https://github.com/the-benchmarker/web-frameworks/issues/3191. I realized that the benchmark app shouldn't even be using the `assets` framework since it doesn't rely on assets at all. Removing the `assets` framework was as easy as removing the metagem from `Gemfile`, which simply defines the standard gemset as a project dependency.

I also changed the command to boot in `ludicrous` mode, which configures the application for benchmarking.

Still can't get the benchmark to run for me locally, but it appears to be some other issue:

```
Successfully tagged ruby.pakyow:latest
[Error]  -- STDERR(.neph/ruby.pakyow/log/log.err) --
  from ../../lib/db/src/db.cr:152:5 in 'build_database'
  from ../../lib/db/src/db.cr:148:5 in 'build_database'
  from ../../lib/db/src/db.cr:116:5 in 'open'
  from ../../tools/src/client.cr:33:5 in 'run'
  from ../../tools/src/client.cr:22:1 in 'parse_and_run'
  from ../../tools/src/client.cr:22:1 in 'run'
  from ../../tools/src/client.cr:116:1 in '__crystal_main'
  from ../../../../../../../usr/local/Cellar/crystal/0.35.1/src/crystal/main.cr:105:5 in 'main_user_code'
  from ../../../../../../../usr/local/Cellar/crystal/0.35.1/src/crystal/main.cr:91:7 in 'main'
  from ../../../../../../../usr/local/Cellar/crystal/0.35.1/src/crystal/main.cr:114:3 in 'main'
```

Other benchmarks, e.g. `ruby.roda` have the exact same issue on my end.