### PR TITLE
[Java/Kotlin] Remove AggressiveOpts

### DIFF
--- a/java/javalin/config.yaml
+++ b/java/javalin/config.yaml
@@ -2,13 +2,13 @@ framework:
   website: javalin.io
   version: 3.9
 
-build: 
+build:
   - mvn compile assembly:single -q
-  
+
 files:
   - target/benchmark-0.0.1-SNAPSHOT-jar-with-dependencies.jar
 
 command: >
   java -server 
-  -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts 
+  -XX:+UseNUMA -XX:+UseParallelGC 
   -cp target/benchmark-0.0.1-SNAPSHOT-jar-with-dependencies.jar benchmark.javalin.Bench profiles=production

--- a/java/jooby/config.yaml
+++ b/java/jooby/config.yaml
@@ -2,13 +2,13 @@ framework:
   website: jooby.io
   version: 2.8
 
-build: 
+build:
   - mvn clean package
-  
+
 files:
   - target/benchmark.jar
 
 command: >
   java -server
-  -Xms4g -Xmx4g -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts -XX:-UseBiasedLocking -XX:+UseStringDeduplication
+  -Xms4g -Xmx4g -XX:+UseNUMA -XX:+UseParallelGC -XX:-UseBiasedLocking -XX:+UseStringDeduplication
   -jar target/benchmark.jar benchmark.App

--- a/java/rapidoid/config.yaml
+++ b/java/rapidoid/config.yaml
@@ -5,12 +5,11 @@ framework:
 build:
   - mvn compile assembly:single -q
 
-files: 
+files:
   - target/benchmark-0.0.1-SNAPSHOT-jar-with-dependencies.jar
 
 command: >
   java -server
-  -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts 
+  -XX:+UseNUMA -XX:+UseParallelGC 
   -cp target/benchmark-0.0.1-SNAPSHOT-jar-with-dependencies.jar
   benchmark.rapidoid.Main profiles=production
-  

--- a/java/spring-framework/config.yaml
+++ b/java/spring-framework/config.yaml
@@ -10,10 +10,10 @@ fixes:
   - apt-get -y update && apt-get -y install wget
   - wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-runner/9.4.31.v20200723/jetty-runner-9.4.31.v20200723.jar -O /usr/share/java/jetty-runner.jar
 
-files: 
+files:
   - target/benchmark-0.0.1-SNAPSHOT.war
 
 command: >
   java 
-  -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts 
+  -XX:+UseNUMA -XX:+UseParallelGC 
   -jar /usr/share/java/jetty-runner.jar --port 3000 target/benchmark-0.0.1-SNAPSHOT.war

--- a/java/struts2/config.yaml
+++ b/java/struts2/config.yaml
@@ -8,4 +8,4 @@ build:
 files:
   - target/struts2-1.0-standalone.jar
 
-command: java -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts -jar target/struts2-1.0-standalone.jar --port 3000
+command: java -XX:+UseNUMA -XX:+UseParallelGC -jar target/struts2-1.0-standalone.jar --port 3000

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -16,5 +16,5 @@ WORKDIR /usr/src/app
 
 COPY --from=build /usr/src/app/build/libs/server.jar /usr/src/app/build/libs/server.jar
 
-CMD java -server -XX:+UseNUMA -XX:+UseParallelGC -XX:+AggressiveOpts -XX:+AlwaysPreTouch -jar /usr/src/app/build/libs/server.jar
+CMD java -server -XX:+UseNUMA -XX:+UseParallelGC -XX:+AlwaysPreTouch -jar /usr/src/app/build/libs/server.jar
 


### PR DESCRIPTION
Hi,

**-XX:+AggressiveOpts** has been deprecated in jdk `11` and is removed after

This `PR` remove it usage. It affects both `java` and `kotlin`

@see https://dzone.com/articles/jdk-13-what-is-aggressiveopts

Regards,

----------

Closes #3135 