### PR TITLE
[PHP] Deleted useless settings for hyperf.

### DIFF
--- a/php/hyperf/config/autoload/server.php
+++ b/php/hyperf/config/autoload/server.php
@@ -31,7 +31,6 @@ return [
         'enable_coroutine' => false,
         'pid_file' => BASE_PATH . '/runtime/hyperf.pid',
         'open_tcp_nodelay' => true,
-        'open_http2_protocol' => true,
         'max_request' => 0,
         'socket_buffer_size' => 2 * 1024 * 1024,
     ],

--- a/php/hyperf/config/autoload/server.php
+++ b/php/hyperf/config/autoload/server.php
@@ -27,12 +27,10 @@ return [
         ],
     ],
     'settings' => [
-        'coroutine' => false,
         'worker_num' => swoole_cpu_num() * 2,
         'enable_coroutine' => false,
         'pid_file' => BASE_PATH . '/runtime/hyperf.pid',
         'open_tcp_nodelay' => true,
-        'max_coroutine' => 100000,
         'open_http2_protocol' => true,
         'max_request' => 0,
         'socket_buffer_size' => 2 * 1024 * 1024,


### PR DESCRIPTION
1. Swoole does not have setting `coroutine`.
2. max_coroutine is useless, when `enable_coroutine` is false.
