### PR TITLE
[Javascript] Add fyrejet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
       - FRAMEWORK=c.kore
       - FRAMEWORK=javascript.koa
       - FRAMEWORK=javascript.fastify
+      - FRAMEWORK=javascript.fyrejet
       - FRAMEWORK=javascript.sails
       - FRAMEWORK=javascript.rayo
       - FRAMEWORK=javascript.polkadot

--- a/javascript/fyrejet/app.js
+++ b/javascript/fyrejet/app.js
@@ -1,0 +1,17 @@
+var fyrejet = require("fyrejet");
+var app = fyrejet();
+app.set("etag", false);
+
+app.get("/", function (req, res) {
+  res.send("");
+});
+
+app.get("/user/:id", function (req, res) {
+  res.send(req.params.id);
+});
+
+app.post("/user", function (req, res) {
+  res.send("");
+});
+
+app.listen(3000, function () {});

--- a/javascript/fyrejet/config.yaml
+++ b/javascript/fyrejet/config.yaml
@@ -1,0 +1,4 @@
+framework:
+  github: fyrejet/fyrejet
+  version: 2.1
+  

--- a/javascript/fyrejet/package.json
+++ b/javascript/fyrejet/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "fyrejet": "~2.1.1"
+  }
+}


### PR DESCRIPTION
This PR adds `Fyrejet`, a web-framework that is supposed to imitate Express APIs and provide greater performance.

I have basically copy-pasted the `express` `app.js` and only changed the `require()` statement to load `fyrejet` instead.

Unfortunately, I haven't been able to make `docker-machine` work properly on my `macOS Catalina` installation, so I haven't been able to check my PR properly.