### PR TITLE
Add R `plumber` and `httpuv`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,8 @@ env:
       - FRAMEWORK=java.javalin
       - FRAMEWORK=java.jooby
       - FRAMEWORK=java.light-4j
+      - FRAMEWORK=r.httpuv
+      - FRAMEWORK=r.plumber
       - FRAMEWORK=r.restrserve
       - FRAMEWORK=fsharp.falco
       - FRAMEWORK=fsharp.suave

--- a/r/httpuv/DESCRIPTION
+++ b/r/httpuv/DESCRIPTION
@@ -1,0 +1,2 @@
+Depends:
+  httpuv (>= 1.5.4)

--- a/r/httpuv/app.R
+++ b/r/httpuv/app.R
@@ -1,0 +1,26 @@
+s <- httpuv::startServer(host = "0.0.0.0", port = 3000,
+  app = list(
+    call = function(req) {
+      path <- req$PATH_INFO
+      body <-
+        if (path == "/" || path == "" || path == "/user") {
+          ""
+        } else {
+          # /user/id path
+          match_info <- regexec("^/id/(.*)", path)
+          user_id <- regmatches(path, match_info)[[1]][2]
+          user_id
+        }
+
+      list(
+        status = 200L,
+        headers = list('Content-Type' = 'text/plain'),
+        body = body
+      )
+    }
+  )
+)
+
+while (TRUE) {
+  httpuv::service()
+}

--- a/r/httpuv/app.R
+++ b/r/httpuv/app.R
@@ -7,7 +7,7 @@ s <- httpuv::startServer(host = "0.0.0.0", port = 3000,
           ""
         } else {
           # /user/id path
-          match_info <- regexec("^/id/(.*)", path)
+          match_info <- regexec("^/user/(.*)", path)
           user_id <- regmatches(path, match_info)[[1]][2]
           user_id
         }

--- a/r/httpuv/config.yaml
+++ b/r/httpuv/config.yaml
@@ -1,3 +1,3 @@
 framework:
-  website: https://github.com/rstudio/httpuv/
-  version: 1.5.4
+  github: rstudio/httpuv
+  version: 1.5

--- a/r/httpuv/config.yaml
+++ b/r/httpuv/config.yaml
@@ -1,0 +1,3 @@
+framework:
+  website: https://github.com/rstudio/httpuv/
+  version: 1.5.4

--- a/r/plumber/DESCRIPTION
+++ b/r/plumber/DESCRIPTION
@@ -1,0 +1,2 @@
+Depends:
+  plumber (>= 1.0.0)

--- a/r/plumber/app.R
+++ b/r/plumber/app.R
@@ -1,0 +1,4 @@
+library(plumber)
+"plumber.R" %>%
+  pr() %>%
+  pr_run(host = "0.0.0.0", port = 3000)

--- a/r/plumber/app.R
+++ b/r/plumber/app.R
@@ -1,4 +1,1 @@
-library(plumber)
-"plumber.R" %>%
-  pr() %>%
-  pr_run(host = "0.0.0.0", port = 3000)
+plumber::plumb("plumber.R")$run(host = "0.0.0.0", port = 3000)

--- a/r/plumber/config.yaml
+++ b/r/plumber/config.yaml
@@ -1,3 +1,3 @@
 framework:
   website: rplumber.io
-  version: 1.0.0
+  version: 1.0

--- a/r/plumber/config.yaml
+++ b/r/plumber/config.yaml
@@ -1,0 +1,3 @@
+framework:
+  website: rplumber.io
+  version: 1.0.0

--- a/r/plumber/plumber.R
+++ b/r/plumber/plumber.R
@@ -2,12 +2,6 @@
 # See https://github.com/the-benchmarker/web-frameworks/issues/3303#issuecomment-694351654
 
 
-# Rules
-# * GET /, SHOULD return a successful status code and an empty string
-# * GET /user/:id, SHOULD return a successful status code and the id
-# * POST /user, SHOULD return a successful status code and an empty string
-
-
 #* @serializer contentType list(type = "text/plain")
 #* @get /
 function() {

--- a/r/plumber/plumber.R
+++ b/r/plumber/plumber.R
@@ -1,0 +1,29 @@
+# While plumber could be made faster, this represents the common setup
+# See https://github.com/the-benchmarker/web-frameworks/issues/3303#issuecomment-694351654
+
+
+# Rules
+# * GET /, SHOULD return a successful status code and an empty string
+# * GET /user/:id, SHOULD return a successful status code and the id
+# * POST /user, SHOULD return a successful status code and an empty string
+
+
+#* @serializer contentType list(type = "text/plain")
+#* @get /
+function() {
+  ""
+}
+
+
+#* @serializer contentType list(type = "text/plain")
+#* @get /user/<id>
+function(id) {
+  id
+}
+
+
+#* @serializer contentType list(type = "text/plain")
+#* @post /user
+function() {
+  ""
+}

--- a/r/plumber/plumber.R
+++ b/r/plumber/plumber.R
@@ -1,4 +1,4 @@
-# While plumber could be made faster, this represents the common setup
+# While plumber could be made ~ 50% faster, this represents the common setup
 # See https://github.com/the-benchmarker/web-frameworks/issues/3303#issuecomment-694351654
 
 


### PR DESCRIPTION
Fixes https://github.com/the-benchmarker/web-frameworks/issues/3303

Updates:
* Adds `r.plumber` framework
* Adds `r.httpuv` framework

---------------


Commands used to tests locally on macOS:

```bash
# install
brew install crystal wrk postgresql docker-machine
/usr/local/opt/postgres/bin/createuser -s postgres

# set up docker
docker-machine rm default --force
docker-machine create default
eval $(docker-machine env default) 

# build
shards build
bin/make config --driver docker-machine

# set up database
export DATABASE_URL=postgresql://postgres@localhost/benchmark
dropdb -U postgres benchmark
createdb -U postgres benchmark
psql -U postgres -d benchmark < .ci/dump.sql

# test
bin/neph r --seq 

# save output
bin/db to_readme
```

Relevant local test output:
|    | Language | Framework | Speed (64) | Speed (256) | Speed (512) |
|----|----------|-----------|-----------:|------------:|------------:|
| 1 | r (4.0)| [httpuv](https://https://github.com/rstudio/httpuv/) (1.5.4) | 987 | 1 012 | 835 |
| 2 | r (4.0)| [plumber](https://rplumber.io) (1.0.0) | 223 | 240 | 229 |
| 3 | r (4.0)| [restrserve](https://restrserve.org) (0.3) | 125 | 103 | 37 |

------------

cc @t-wojciech