### PR TITLE
[Javascript] Add Fyrejet API mode & Fyrejet on uWebSockets.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ env:
       - FRAMEWORK=javascript.koa
       - FRAMEWORK=javascript.fastify
       - FRAMEWORK=javascript.fyrejet
+      - FRAMEWORK=javascript.fyrejet-uwebsockets
+      - FRAMEWORK=javascript.fyrejet-api
       - FRAMEWORK=javascript.sails
       - FRAMEWORK=javascript.rayo
       - FRAMEWORK=javascript.polkadot

--- a/javascript/fyrejet-api/app.js
+++ b/javascript/fyrejet-api/app.js
@@ -1,0 +1,18 @@
+var fyrejet = require("fyrejet");
+var app = fyrejet();
+
+app.set('fyrejet mode', 'api')
+
+app.get("/", function (req, res) {
+  res.send("");
+});
+
+app.get("/user/:id", function (req, res) {
+  res.send(req.params.id);
+});
+
+app.post("/user", function (req, res) {
+  res.send("");
+});
+
+app.listen(3000, function () {});

--- a/javascript/fyrejet-api/app.js
+++ b/javascript/fyrejet-api/app.js
@@ -1,7 +1,7 @@
 var fyrejet = require("fyrejet");
 var app = fyrejet();
 
-app.set('fyrejet mode', 'api')
+app.set('fyrejet mode', 'api');
 
 app.get("/", function (req, res) {
   res.send("");

--- a/javascript/fyrejet-api/config.yaml
+++ b/javascript/fyrejet-api/config.yaml
@@ -1,4 +1,4 @@
 framework:
   github: fyrejet/fyrejet
   version: 2.1
-  
+

--- a/javascript/fyrejet-api/config.yaml
+++ b/javascript/fyrejet-api/config.yaml
@@ -1,0 +1,4 @@
+framework:
+  github: fyrejet/fyrejet
+  version: 2.1
+  

--- a/javascript/fyrejet-api/package.json
+++ b/javascript/fyrejet-api/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "fyrejet": "~2.1.1"
+  }
+}

--- a/javascript/fyrejet-uwebsockets/app.js
+++ b/javascript/fyrejet-uwebsockets/app.js
@@ -1,0 +1,22 @@
+var fyrejet = require("fyrejet");
+var app = fyrejet({
+  prioRequestsProcessing: false,
+  server: fyrejet.uwsCompat(),
+  serverType: 'uWebSockets'
+});
+
+app.set("etag", false);
+
+app.get("/", function (req, res) {
+  res.send("");
+});
+
+app.get("/user/:id", function (req, res) {
+  res.send(req.params.id);
+});
+
+app.post("/user", function (req, res) {
+  res.send("");
+});
+
+app.listen(3000, function () {});

--- a/javascript/fyrejet-uwebsockets/config.yaml
+++ b/javascript/fyrejet-uwebsockets/config.yaml
@@ -1,4 +1,4 @@
 framework:
   github: fyrejet/fyrejet
   version: 2.1
-  
+

--- a/javascript/fyrejet-uwebsockets/config.yaml
+++ b/javascript/fyrejet-uwebsockets/config.yaml
@@ -1,0 +1,4 @@
+framework:
+  github: fyrejet/fyrejet
+  version: 2.1
+  

--- a/javascript/fyrejet-uwebsockets/config.yaml
+++ b/javascript/fyrejet-uwebsockets/config.yaml
@@ -2,3 +2,8 @@ framework:
   github: fyrejet/fyrejet
   version: 2.1
 
+build_deps:
+  - git
+
+bin_deps:
+  -  gcompat # required by uWebSocket

--- a/javascript/fyrejet-uwebsockets/package.json
+++ b/javascript/fyrejet-uwebsockets/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "fyrejet": "~2.1.1",
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v18.5.0"
+  }
+}


### PR DESCRIPTION
I am not sure, whether this should be included, but the framework I created and added as part of #3322 supports [using uWebSockets.js](https://github.com/fyrejet/fyrejet#uwebsockets), as well as working [without Express's additions to `req` & `res`](https://github.com/fyrejet/fyrejet#special-routing-modes-). Therefore, I am sending this PR.