### PR TITLE
[Crystal] Clarify shivneri version

### DIFF
--- a/crystal/shivneri/shard.yml
+++ b/crystal/shivneri/shard.yml
@@ -13,4 +13,4 @@ license: MIT
 dependencies:
   shivneri:
     github: ujjwalguptaofficial/shivneri
-    version: ~> 0.16
+    version: ~> 0.16.0


### PR DESCRIPTION
Hi @ujjwalguptaofficial,

This `PR` clarify version in use for https://github.com/ujjwalguptaofficial/shivneri.

`0.16` means 0.16 and over (in 0.x), but `0.16.0` means anything in 0.16.x (and that what we show in the result set)

Regards,