### PR TITLE
adding low-http-server

### DIFF
--- a/javascript/low-http-server/app.js
+++ b/javascript/low-http-server/app.js
@@ -1,0 +1,20 @@
+const low = require('low-http-server')
+const cero = require('0http')
+
+const { router, server } = cero({
+  server: low()
+})
+
+router.on('GET', '/', (req, res) => {
+  res.end()
+})
+
+router.on('GET', '/user/:id', (req, res) => {
+  res.end(req.params.id)
+})
+
+router.on('POST', '/user', (req, res) => {
+  res.end()
+})
+
+server.listen(3000)

--- a/javascript/low-http-server/config.yaml
+++ b/javascript/low-http-server/config.yaml
@@ -1,3 +1,9 @@
 framework:
   github: jkyberneees/low-http-server
   version: 2.1
+
+build_deps:
+  - git
+
+bin_deps:
+  - gcompat # required by uWebSocket

--- a/javascript/low-http-server/config.yaml
+++ b/javascript/low-http-server/config.yaml
@@ -1,0 +1,3 @@
+framework:
+  github: jkyberneees/low-http-server
+  version: 2.1

--- a/javascript/low-http-server/package.json
+++ b/javascript/low-http-server/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "low-http-server": "~2.1.1",
+    "0http": "~3.0.0"
+  }
+}

--- a/reviewers.yaml
+++ b/reviewers.yaml
@@ -1,6 +1,8 @@
 javascript:
   0http:
     - jkyberneees
+  low-http-server:
+    - jkyberneees
   restana:
     - jkyberneees
   fastify:


### PR DESCRIPTION
Adding [low-http-server](https://github.com/jkyberneees/low-http-server) HTTP server implementation. Here we are using `0http` as routing layer.
> This implementation is also based on uWebSockets!