### PR TITLE
[C++] Add nawa

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -919,6 +919,9 @@ blocks:
       commands:
       - cd cpp/evhtp && make build  -f .Makefile  && cd -
       - FRAMEWORK=cpp/evhtp bundle exec rspec .spec
+    - name: nawa
+      commands:
+      - cd cpp/nawa && make build  -f .Makefile  && cd -
 - name: swift
   dependencies:
   - setup

--- a/cpp/nawa/CMakeLists.txt
+++ b/cpp/nawa/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.13)
+project(nawa_benchmark)
+
+set(CMAKE_CXX_STANDARD 17)
+
+set(BuildExamples OFF CACHE INTERNAL "")
+set(BuildDocs OFF CACHE INTERNAL "")
+set(BuildSharedLib ON CACHE INTERNAL "")
+set(EnableArgon2 OFF CACHE INTERNAL "")
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+add_subdirectory(nawa)
+target_link_libraries(${PROJECT_NAME} PRIVATE nawa)

--- a/cpp/nawa/config.ini
+++ b/cpp/nawa/config.ini
@@ -1,0 +1,93 @@
+[http]
+; IP address (of an interface) to listen on
+; default value: 127.0.0.1
+listen = 0.0.0.0
+; TCP port to listen on (for port numbers < 1000, NAWA needs to be started as root)
+; default value: 8080
+port = 3000
+; set SO_REUSEADDR socket option
+; default value: on
+reuseaddr = on
+
+[post]
+; Maximum post size (in kiB)
+; default value: 0
+max_size = 1000
+; Access to raw post data (requires copying) always possible (always), never (never), or just for non-standard
+; content types (nonstandard), i.e., all except application/x-www-form-urlencoded and multipart/form-data
+; default value: nonstandard
+; possible values: always, nonstandard, never
+raw_access = nonstandard
+
+[system]
+; Fixed number of threads (fixed) or relative to std::thread::hardware_concurrency (hardware)
+; default value: fixed
+concurrency = fixed
+; number of threads, absolute (fixed concurrency) or relative (threads*hardware_concurrency) (double)
+; default value: 1.0
+threads = 8.0
+; Request handler to use
+; default value: fastcgi
+; possible values: fastcgi, http (the latter one should be used for development purposes only)
+request_handler = http
+
+[application]
+; Path to application to load
+path = ./cmake-build-debug/libnawatest.so
+
+[session]
+; Name of the session cookie
+; default value: SESSION
+cookie_name = SESSION
+; For session cookie properties, please note the precedence:
+; - (highest) passing a Cookie parameter to Session::start() -> the following 3 cookie_* properties will be ignored
+; - properties defined here
+; - (lowest) Connection::setCookiePolicy(Cookie)
+; -> boolean properties (Secure, HttpOnly): will be set if true/on anywhere,
+;    integral properties (SameSite, Max-Age): value with highest precedence that is >0 will be taken
+
+; Enable this option if session cookies may only be sent via secure (HTTPS) connections. Sessions will not work on
+; unencrypted (HTTP) connections if this option is set to on.
+; default value: off
+cookie_secure = off
+; Set this to off if httpOnly attribute should not be set in the cookie (making it modifiable through JS, danger of XSS)
+; (not yet supported by all browsers, but at least protects those with a compatible browser)
+; default value: on
+cookie_httponly = on
+; If set to lax, cookie may be sent with some cross-site GET requests, if off, cookie may be sent with all XS requests
+; strict is recommended, sending the cookie with XS requests is then prohibited (not yet supported by all browsers)
+; default value: strict
+; possible values: strict, lax, off
+cookie_samesite = strict
+
+; Set this to off if the cookie should not include an explicit Expires and Max-Age property (according to keepalive)
+; (the browser will then delete it when it closes)
+; WARNING: CookiePolicy sets absolute values for Expires and Max-Age and might make proper session handling impossible,
+; therefore, it is recommended to leave this on.
+; default value: on
+cookie_expires = on
+; How many seconds should a session be kept alive (server-side) without being touched by Session::start() or autostart?
+; (i.e., in general, the maximum time a user can be inactive without having its session closed)
+; Sessions never outlive the runtime of the NAWA process and cannot be set to being "infinite".
+; Use a database if you want to implement "permanent sessions"/"stay logged in".
+; default value: 1800
+keepalive = 3600
+; Automatically start a session when a user connects? (on/off)
+; Please note that session starting might slow down connections due to the synchronization overhead with other calls.
+; We recommend to leave this off and not to start sessions for resources that do not need them,
+; such as images, styles, JS, etc.
+; default value: off
+autostart = off
+; Bind sessions to IP addresses, and if yes, what to do in case of an IP mismatch?
+; (might cause problems with switching between WiFi and mobile networks, recommended only for security sensitive apps)
+; possible values: strict (invalidate session when accessed with different IP), lax (ignore access), off
+; default value: off
+validate_ip = off
+; Probability that the garbage collector will be run while running Session::start() is 1/(gc_divisor).
+; default value: 100 (i.e., 1% chance)
+gc_divisor = 100
+
+[crypto]
+; Cost factor for salt generation for password hashing using the bcrypt algorithm. May be increased on stronger hardware.
+; default value: 12
+bcrypt_cost = 12

--- a/cpp/nawa/config.yaml
+++ b/cpp/nawa/config.yaml
@@ -1,0 +1,35 @@
+framework:
+  github: jatofg/nawa
+  version: 0.6
+
+build_deps:
+  - libssl-dev
+  - libboost-dev
+  - libcurl4-dev
+  - libboost-system-dev
+  - libboost-thread-dev
+
+bin_deps:
+  - libcurl4
+  - libboost-system1.65.1
+  - libboost-thread1.65.1
+
+deps:
+  - openssl
+
+binaries:
+  - build/nawa_benchmark
+
+download:
+  - git clone --branch v0.6.0 https://github.com/jatofg/nawa
+  - cd nawa && git submodule update --init
+
+build:
+  - mkdir build
+  - cd build && cmake -DCMAKE_BUILD_TYPE=release ..
+  - cd build && make
+
+files:
+  - config.ini
+
+command: /opt/web/build/nawa_benchmark /opt/web/config.ini

--- a/cpp/nawa/main.cpp
+++ b/cpp/nawa/main.cpp
@@ -1,0 +1,72 @@
+#include <iostream>
+#include <nawa/RequestHandlers/RequestHandler.h>
+#include <nawa/Exception.h>
+#include <nawa/Connection.h>
+
+using namespace nawa;
+using namespace std;
+
+int main(int argc, char const *argv[]) {
+	
+	// Please note that this app uses nawa as a library, it can also be used as an IoC-style
+	// framework, making it even easier to write and run apps, see https://github.com/jatofg/nawa
+
+    if (argc < 2) {
+        std::cout << "please provide the config file name" << std::endl;
+        return -1;
+    }
+
+    // Load the config from the given ini file
+    Config config;
+    try {
+        config.read(argv[1]);
+    }
+    catch (const Exception &e) {
+        cerr << "Could not read config.ini file: " << e.getMessage() << endl;
+        return -1;
+    }
+
+    // function which handles the requests
+    auto handlingFunction = [](Connection& connection) -> int {
+
+        auto requestPath = connection.request.env.getRequestPath();
+
+        if (requestPath.size() == 2 && requestPath[0] == "user") {
+            connection.setBody(requestPath[1]);
+            return 0;
+        } else if (requestPath.size() == 1 && requestPath[0] == "user" 
+			&& connection.request.env["REQUEST_METHOD"] == "POST") {
+			return 0;
+		} else if (requestPath.size() == 0) {
+			return 0;
+		}
+		
+		connection.setStatus(400);
+        return 0;
+
+    };
+
+    // set up the NAWA request handler
+    unique_ptr<RequestHandler> requestHandler;
+    try {
+        // The last argument is the concurrency, which is the number of worker threads for processing requests
+        requestHandler = RequestHandler::newRequestHandler(handlingFunction, config, 8);
+    }
+    catch (const Exception &e) {
+        cerr << "NAWA request handler could not be created: " << e.getMessage() << endl;
+        return -1;
+    }
+
+    // start handling requests
+    try {
+        requestHandler->start();
+    } catch (const Exception &e) {
+        cerr << "NAWA request handling could not be started: " << e.getMessage() << endl;
+        return -1;
+    }
+
+    // block until request handling has terminated
+    requestHandler->join();
+
+    return 0;
+}


### PR DESCRIPTION
Add the nawa framework (issue #3634). As mentioned in the issue, I was unable to test whether the integration into the benchmark suite works. Feel free to adapt the PR as you like.

To me, it looks like the suite is run on Ubuntu 18.04, so I've set the dependencies in config.yaml accordingly. Unfortunately, Ubuntu doesn't provide a meta package for the most recent versions of libboost-system and libboost-thread, so if it were to be run on another OS, the following binary dependencies would have to be adapted (by setting the version accordingly):
* libboost-system1.65.1 (would be libboost-system1.71.0 on 20.04)
* libboost-thread1.65.1 (would be libboost-thread1.71.0 on 20.04)