### PR TITLE
Reverts Jetty version, v11 is not supported by Struts

### DIFF
--- a/java/struts2/pom.xml
+++ b/java/struts2/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>11.0.0</jetty.version>
+        <jetty.version>9.4.35.v20201120</jetty.version>
         <jetty-jsp.version>9.2.30.v20200428</jetty-jsp.version>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
Jetty v11 (JakartaEE Servlet API) is not supported by the Apache Struts 2.5.x yet.