### PR TITLE
[Clojure] Update luminus to 3.91

### DIFF
--- a/clojure/luminus/config.yaml
+++ b/clojure/luminus/config.yaml
@@ -1,6 +1,6 @@
 framework:
   website: luminusweb.com
-  version: 1.0
+  version: 3.91
 
 image: clojure:openjdk-11-lein-slim-buster
 

--- a/clojure/luminus/project.clj
+++ b/clojure/luminus/project.clj
@@ -1,6 +1,7 @@
 (defproject luminus "0.1.0-SNAPSHOT"
 
-  :dependencies [[ch.qos.logback/logback-classic "1.2.3"]
+  :dependencies [[luminus/lein-template "3.91"]
+                 [ch.qos.logback/logback-classic "1.2.3"]
                  [cheshire "5.10.0"]
                  [clojure.java-time "0.3.2"]
                  [cprop "0.1.17"]
@@ -24,7 +25,7 @@
                  [ring-webjars "0.2.0"]
                  [ring/ring-core "1.8.2"]
                  [ring/ring-defaults "0.3.2"]
-                 [selmer "1.12.31"]]
+                 [com.fasterxml.jackson.core/jackson-core "2.12.0"]]
 
   :min-lein-version "2.0.0"
   


### PR DESCRIPTION
Hi @yogthos,

This `PR` update luminus to 3.91.

Could you confirm that we are using 3.91 ?

Could also review this ? I do not know about clojure but `project.cjl` seems to list a lot of dependencies, shouldn't this deps handle by luminus-template ?

Regards,

------
Closes #3638 

------
Without `[com.fasterxml.jackson.core/jackson-core "2.12.0"]` I have a `com.fasterxml.jackson.core.util.JacksonFeature` at compile time