### PR TITLE
[C] Upgrade kore to 4.0

### DIFF
--- a/c/kore/config.yaml
+++ b/c/kore/config.yaml
@@ -1,6 +1,6 @@
 framework:
   website: kore.io
-  version: 3.3
+  version: 4.0
 
 provider:
   default:
@@ -14,9 +14,9 @@ files:
   - "**/hello.conf"
 
 download:
-  - wget -c https://kore.io/releases/kore-3.3.1.tar.gz
-  - tar -xvf kore-3.3.1.tar.gz
-  - cd kore-3.3.1 && TASKS=1 NOTLS=1 make && make install
+  - wget -c https://github.com/jorisvink/kore/archive/4.0.1.tar.gz
+  - tar -xvf 4.0.1.tar.gz
+  - cd kore-4.0.1 && TASKS=1 NOTLS=1 make && make install
 
 build:
   - cd hello && kodev build
@@ -26,6 +26,7 @@ build:
 build_deps:
   - bsd-compat-headers
   - libressl-dev
+  - audit-dev
 
 bin_deps:
   - libressl


### PR DESCRIPTION
Hi @jorisvink,

I've issues compiling 4.0 on alpine. 

I have 

```
In file included from src/hello.c:1:
/usr/local/include/kore/http.h:240:2: error: unknown type name 'regex_t'
  240 |  regex_t    rctx;
      |  ^~~~~~~
/usr/local/include/kore/http.h:282:2: error: unknown type name 'regmatch_t'
  282 |  regmatch_t cgroups[HTTP_CAPTURE_GROUPS];
```

gcc version is 9.3.0

Regards,