### PR TITLE
Run CI regularly 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,13 @@
 name: CI
 
-on: [pull_request]
-
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+  schedule:
+    - cron: 0 0 * * 1 # every monday
 jobs:
   dynamic_matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hi,

This `PR` adds a schedule (every monday) to run a full CI.

The idea is to ensure that all frameworks (last versions) are working correctly.

Regards,