### PR TITLE
Rust with musl has a performance issue

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -2,21 +2,8 @@ FROM rust:1.49 AS build
 
 WORKDIR /usr/src/app
 
-RUN apt-get update && apt-get -y install musl-tools --no-install-recommends \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get -y install musl-tools --no-install-recommends
-
-RUN rustup target add x86_64-unknown-linux-musl
-
 COPY . ./
 
-RUN cargo build --target x86_64-unknown-linux-musl --release
+RUN cargo install --path .
 
-# hadolint ignore=DL3006
-FROM alpine
-
-COPY --from=build /usr/src/app/target/x86_64-unknown-linux-musl/release/server /usr/src/app/target/x86_64-unknown-linux-musl/release/server
-
-CMD /usr/src/app/target/x86_64-unknown-linux-musl/release/server
+CMD /usr/local/cargo/bin/server

--- a/rust/actix/src/main.rs
+++ b/rust/actix/src/main.rs
@@ -1,9 +1,7 @@
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
 
 #[get("/user/{id}")]
-async fn get_user(web::Path(id): web::Path<String>) -> impl Responder {
-    id.to_string()
-}
+async fn get_user(web::Path(id): web::Path<String>) -> impl Responder { id }
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/70108
musl-libc seems to be slow when running multithreaded.
Is it a regulation every executable is portable?
I recommend to use x86_64-unknown-linux-gnu.

my environment: Linux version 5.10.2-2-MANJARO (builduser@LEGION) (gcc (GCC) 10.2.0, GNU ld (GNU Binutils) 2.35.1) #1 SMP PREEMPT Tue Dec 22 08:14:42 UTC 2020