### PR TITLE
[FIX] fix php/fatfree index not being in the public dir

### DIFF
--- a/php/fatfree/public/index.php
+++ b/php/fatfree/public/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require 'vendor/autoload.php';
+require '../vendor/autoload.php';
 
 $f3 = Base::instance();
 


### PR DESCRIPTION
didn't see fat free in the results so I checked CI logs and noticed 500 returned by nginx 

I made a mistake in previous PR - I didnt move index.php into public dir

should be fine now