### PR TITLE
[PHP] antidot PHP8 support

### DIFF
--- a/php/antidot/composer.json
+++ b/php/antidot/composer.json
@@ -13,7 +13,7 @@
     "ext-json": "*",
     "antidot-fw/react-framework": "~1.0.3",
     "antidot-fw/fast-router-adapter": "~0.1.1",
-    "antidot-fw/container": "~0.1.5",
+    "antidot-fw/container": "~0.1.4",
     "antidot-fw/framework": "~0.1.3",
     "antidot-fw/symfony-config-translator": "~1.1.2",
     "antidot-fw/yaml-config-provider": "~0.1.2",


### PR DESCRIPTION
Fix "antidot-framework/container" version. The added version was a tagging mistake. 
The 0.1.5 tag points to the 0.1.3 release that does not have support with PHP 8. I removed this tag and down the composer.json version to the correct one, the 0.1.4. 

Related to https://github.com/the-benchmarker/web-frameworks/pull/3655 thanks @waghanza ;- D
