### PR TITLE
Do not test Rust on musl

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,22 +1,13 @@
-FROM rust:1.50 AS build
+FROM rust:1.50-slim AS build
 
 WORKDIR /usr/src/app
 
-RUN apt-get update && apt-get -y install musl-tools --no-install-recommends \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get -y install musl-tools --no-install-recommends
-
-RUN rustup target add x86_64-unknown-linux-musl
-
 COPY . ./
 
-RUN cargo build --target x86_64-unknown-linux-musl --release
+RUN cargo build --release && strip target/release/server
 
-# hadolint ignore=DL3006
-FROM alpine
+FROM debian:buster-slim
 
-COPY --from=build /usr/src/app/target/x86_64-unknown-linux-musl/release/server /usr/src/app/target/x86_64-unknown-linux-musl/release/server
+COPY --from=build /usr/src/app/target/release/server /usr/src/app/target/release/server
 
-CMD /usr/src/app/target/x86_64-unknown-linux-musl/release/server
+CMD /usr/src/app/target/release/server


### PR DESCRIPTION
I just noticed that you compile all rust frameworks for the `x86_64-unknown-linux-musl` target which is known to be much slower for most Rust programms due to something related to musl's allocator. Changing the target to debian, I saw performance uplift by factor 5 for the `rust/gotham` framework, which is probably more than what is caused by unpredictable Ryzen boosting behaviour:

**Before** (`alpine`)

```
benchmark=# select avg(value) from values where key_id = 3;
  avg  
-------
 90456
(1 row)
```

**After** (`debian:buster-slim`)

```
benchmark=# select avg(value) from values where key_id = 3;
  avg   
--------
 453782
(1 row)
```