### PR TITLE
[Go] Add incompatibility flag to kami

### DIFF
--- a/go/kami/go.mod
+++ b/go/kami/go.mod
@@ -1,3 +1,3 @@
 module main
 
-require github.com/guregu/kami v2.2.1
+require github.com/guregu/kami v2.2.1+incompatible


### PR DESCRIPTION
Hi,

`kami` could not compile will the latest version of go (at least **1.16**), all deps are not ready to use go modules, as I understand
https://the-benchmarker.semaphoreci.com/jobs/95b82f51-fae7-4a5a-9a73-74f6be6d6ace#L335

Regards,