### PR TITLE
[Python] Use built-in server for tornado

### DIFF
--- a/python/tornado/config.yaml
+++ b/python/tornado/config.yaml
@@ -2,11 +2,4 @@ framework:
   website: tornadoweb.org
   version: 6.1
 
-command: >
-  gunicorn  \
-    --log-level warning  \
-    --bind 0.0.0.0:3000  \
-    --reuse-port  \
-    --workers $(nproc)  \
-    --worker-class gunicorn.workers.gtornado.TornadoWorker \
-      server:app
+command: python /usr/src/app/server.py

--- a/python/tornado/requirements.txt
+++ b/python/tornado/requirements.txt
@@ -1,2 +1,1 @@
 tornado>=6.1,<6.2
-gunicorn

--- a/python/tornado/server.py
+++ b/python/tornado/server.py
@@ -24,10 +24,16 @@ class UserInfoHandler(tornado.web.RequestHandler):
         self.write(id)
 
 
-app = tornado.web.Application(
-    handlers=[
-        (r"/", MainHandler),
-        (r"/user", UserHandler),
-        (r"/user/(\d+)", UserInfoHandler),
-    ]
-)
+def main():
+    app = tornado.web.Application(
+        handlers=[
+            (r"/", MainHandler),
+            (r"/user", UserHandler),
+            (r"/user/(\d+)", UserInfoHandler),
+        ]
+    )
+    app.listen(3000)
+    tornado.ioloop.IOLoop.current().start()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hi,

This `PR` switch from `gunicorn` worker to `tornado` _built-in_ server.

The idea is to use what frameworks are, and only rely of external lib if non is built-in (and suitable for **production**).

Same idea for `sanic`.

Regards,

@bdarnell Can you confirm the built-in server is **production** _ready_ ? What is your recommandation, if not ?