### PR TITLE
DriftPHP to persistent connections

### DIFF
--- a/php/driftphp/composer.json
+++ b/php/driftphp/composer.json
@@ -11,7 +11,8 @@
     "symfony/framework-bundle": "*",
     "symfony/yaml": "*",
     "drift/http-kernel": "~0.1.7",
-    "drift/server": "~0.1.17"
+    "drift/server": "~0.1.23",
+    "react/http": "dev-master#7aa08f01583c765261d08d1191f0239324f18012 as 1.2.1"
   },
   "autoload": {
     "psr-4": {

--- a/php/driftphp/config.yaml
+++ b/php/driftphp/config.yaml
@@ -10,4 +10,4 @@ php_mod:
   - posix
   - sockets
 
-command: php vendor/bin/server run 0.0.0.0:3000 --env=prod --quiet --workers=-1
+command: php vendor/bin/server run 3000 --env=prod --quiet --workers=-1


### PR DESCRIPTION
### Edited from this original

Somehow, only 1 worker is being used for this benchmark. By setting this value to 8, all available cores should be used now.

Added as well a more relaxed quiet mode for checking errors