### PR TITLE
[Haskell] Update servant to 0.18

### DIFF
--- a/haskell/servant/config.yaml
+++ b/haskell/servant/config.yaml
@@ -1,3 +1,3 @@
 framework:
-  website: servant.dev
-  version: 0.17
+  website: docs.servant.dev
+  version: 0.18

--- a/haskell/servant/server.cabal
+++ b/haskell/servant/server.cabal
@@ -10,7 +10,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Lib
   build-depends:       base >= 4.7 && < 5
-                     , servant >= 0.17 && < 0.18
+                     , servant >= 0.18 && < 0.19
                      , servant-server
                      , wai
                      , warp


### PR DESCRIPTION
Hi,

This `PR` updates https://github.com/haskell-servant/servant to **0.18**.

May I notify you on any update `here` that can affect https://github.com/haskell-servant/servant @jkarni @gdeest @phadej ?

Regards,