### PR TITLE
fix typo minimim to minimum

### DIFF
--- a/.tasks/collect.rake
+++ b/.tasks/collect.rake
@@ -69,7 +69,7 @@ task :collect do
         lua_output = stderr.read
         lua_keys = ['duration_ms', 'total_requests', 'total_requests_per_s', 'total_bytes_received',
          'socket_connection_errors', 'socket_read_errors', 'socket_write_errors',
-         'http_errors', 'request_timeouts', 'minimim_latency', 'maximum_latency',
+         'http_errors', 'request_timeouts', 'minimum_latency', 'maximum_latency',
          'average_latency', 'standard_deviation', 'percentile_50',
          'percentile_75', 'percentile_90', 'percentile_99', 'percentile_99.999']
 

--- a/pipeline.lua
+++ b/pipeline.lua
@@ -7,7 +7,7 @@
 -- total socket write errors
 -- total http errors (status > 399)
 -- total request timeouts
--- minimim latency
+-- minimum latency
 -- maximum latency
 -- average latency
 -- standard deviation

--- a/pipeline_post.lua
+++ b/pipeline_post.lua
@@ -11,7 +11,7 @@ wrk.headers["Content-Type"] = "application/x-www-form-urlencoded"
 -- total socket write errors
 -- total http errors (status > 399)
 -- total request timeouts
--- minimim latency
+-- minimum latency
 -- maximum latency
 -- average latency
 -- standard deviation


### PR DESCRIPTION
From #4174, I noticed there are output typo on the `.json` file, metric label `minimim_latency` supposed to be `minimum_latency`. This PR fixes the typo.