### PR TITLE
[PHP] Duplicate posix extension load

### DIFF
--- a/php/antidot/config.yaml
+++ b/php/antidot/config.yaml
@@ -9,7 +9,6 @@ build_deps:
 php_mod:
   - intl
   - pcntl
-  - posix
   - sockets
 
 before_command:

--- a/php/chubbyphp-workerman/config.yaml
+++ b/php/chubbyphp-workerman/config.yaml
@@ -7,7 +7,6 @@ build_deps:
 
 php_mod:
   - pcntl
-  - posix
   - sockets
 
 php_ext:

--- a/php/comet/config.yaml
+++ b/php/comet/config.yaml
@@ -4,6 +4,5 @@ framework:
 
 php_mod:
   - pcntl
-  - posix
 
 command: php start.php start

--- a/php/driftphp/config.yaml
+++ b/php/driftphp/config.yaml
@@ -7,7 +7,6 @@ build_deps:
 
 php_mod:
   - pcntl
-  - posix
   - sockets
 
 command: php vendor/bin/server run 0.0.0.0:3000 --env=prod --quiet --workers=-1

--- a/php/laravel-s-laravel/config.yaml
+++ b/php/laravel-s-laravel/config.yaml
@@ -4,7 +4,6 @@ framework:
 
 php_mod:
   - pcntl
-  - posix
 
 php_ext:
   - swoole

--- a/php/laravel-s-lumen/config.yaml
+++ b/php/laravel-s-lumen/config.yaml
@@ -4,7 +4,6 @@ framework:
 
 php_mod:
   - pcntl
-  - posix
 
 php_ext:
   - swoole

--- a/php/mark/config.yaml
+++ b/php/mark/config.yaml
@@ -4,6 +4,5 @@ framework:
 
 php_mod:
   - pcntl
-  - posix
 
 command: php start.php start

--- a/php/nano/config.yaml
+++ b/php/nano/config.yaml
@@ -4,6 +4,5 @@ framework:
 
 php_mod:
   - pcntl
-  - posix
 
 command: php index.php start

--- a/php/webman/config.yaml
+++ b/php/webman/config.yaml
@@ -7,7 +7,6 @@ build_deps:
 
 php_mod:
   - pcntl
-  - posix
   - sockets
 
 php_ext:

--- a/php/workerman/config.yaml
+++ b/php/workerman/config.yaml
@@ -7,7 +7,6 @@ build_deps:
 
 php_mod:
   - pcntl
-  - posix
   - sockets
 
 php_ext:


### PR DESCRIPTION
Hi,

It appears that **posix** extension is already loaded by **pcnl**.

No need to use `docker-php-ext-install` in this case.

Regards,