### PR TITLE
Swift disable runtime exclusivity checks

### DIFF
--- a/swift/.gitignore
+++ b/swift/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+.build/
+/*.xcodeproj
+xcuserdata/
+.swiftpm/
+DerivedData/
+Package.resolved

--- a/swift/Dockerfile
+++ b/swift/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/src/app
 COPY Package.swift ./
 COPY Sources/ ./Sources/
 
-RUN swift build -c release
+RUN swift build -c release -Xswiftc -enforce-exclusivity=unchecked
 
 FROM swift:5.3-slim
 {{#environment}}


### PR DESCRIPTION
Optimization for all swift builds. Disables swift runtime memory exclusivity checks.

cc @0xTim 

Also added .gitignore for all swift builds