### PR TITLE
[haskell]: setting lts to 17.11

### DIFF
--- a/haskell/scotty/stack.yaml
+++ b/haskell/scotty/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.12
+resolver: lts-17.11
 
 allow-newer: true
 

--- a/haskell/servant/stack.yaml
+++ b/haskell/servant/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.12
+resolver: lts-17.11
 
 allow-newer: true
 


### PR DESCRIPTION
Upgrading Haskell lts to latest