### PR TITLE
Fix website for Flask

### DIFF
--- a/python/flask/config.yaml
+++ b/python/flask/config.yaml
@@ -1,5 +1,5 @@
 framework:
-  website: flask.pocoo.org
+  website: www.palletsprojects.com/p/flask/
   version: 2.0
 
 command: >


### PR DESCRIPTION
See https://www.pocoo.org/. Flask is now hosted by palletsprojects.com