### PR TITLE
[PHP] Upgrade swoole to v4.7

### DIFF
--- a/php/swoole-coroutine/composer.json
+++ b/php/swoole-coroutine/composer.json
@@ -1,5 +1,5 @@
 {
   "require": {
-    "ext-swoole": "~4.6.0"
+    "ext-swoole": "~4.7.0"
   }
 }

--- a/php/swoole-coroutine/config.yaml
+++ b/php/swoole-coroutine/config.yaml
@@ -1,6 +1,6 @@
 framework:
   github: swoole/swoole-src
-  version: 4.6
+  version: 4.7
 
 php_ext:
   - swoole

--- a/php/swoole/composer.json
+++ b/php/swoole/composer.json
@@ -1,5 +1,5 @@
 {
   "require": {
-    "ext-swoole": "~4.6.0"
+    "ext-swoole": "~4.7.0"
   }
 }

--- a/php/swoole/config.yaml
+++ b/php/swoole/config.yaml
@@ -1,6 +1,6 @@
 framework:
   github: swoole/swoole-src
-  version: 4.6
+  version: 4.7
 
 php_ext:
   - swoole


### PR DESCRIPTION
This is not a real upgrade (since v4.7 is installed with `pecl install swoole`), more a fix / alignment with the doc