### PR TITLE
[PHP] Antidot react: Fix max concurrency issues

### DIFF
--- a/php/antidot/config.yaml
+++ b/php/antidot/config.yaml
@@ -20,4 +20,4 @@ before_command:
   - mkdir -p var/cache && chmod 777 var/cache
   - mkdir -p var/log && chmod 777 var/log
 
-command: bin/console server:run
+command: bin/console server:run --quiet

--- a/php/antidot/config/config.php
+++ b/php/antidot/config/config.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 use Antidot\SymfonyConfigTranslator\Container\Config\ConfigAggregator;
 use Antidot\Yaml\YamlConfigProvider;
 use Laminas\ConfigAggregator\ArrayProvider;
-use Laminas\ConfigAggregator\PhpFileProvider;
+
+ini_set('memory_limit', '256M');
 
 $cacheConfig = [
     'config_cache_path' => 'var/cache/config-cache.php',
@@ -17,7 +18,6 @@ $aggregator = new ConfigAggregator([
     \Antidot\Container\Config\ConfigProvider::class,
     \Antidot\React\Container\Config\ConfigProvider::class,
     \Antidot\React\PSR15\Container\Config\ConfigProvider::class,
-    new PhpFileProvider(realpath(__DIR__).'/services/{{,*.}prod,{,*.}local,{,*.}dev}.php'),
     new YamlConfigProvider(realpath(__DIR__).'/services/{{,*.}prod,{,*.}local,{,*.}dev}.yaml'),
     new ArrayProvider($cacheConfig),
 ], $cacheConfig['config_cache_path']);

--- a/php/antidot/config/services/dependencies.prod.yaml
+++ b/php/antidot/config/services/dependencies.prod.yaml
@@ -9,6 +9,6 @@ parameters:
   server:
     host: "0.0.0.0"
     port: 3000
-    max_concurrency: 4096
+    max_concurrency: 512
     buffer_size: 2048
     workers: -1


### PR DESCRIPTION
Hi @waghanza, after some research, I met that the allowed max concurrency were overloading PHP's memory since it breaks, I make some test locally and I look nice performance improvement by incrementing the PHP memory limit to 256M and by limiting the React-PHP HTTP server max concurrency to 512 requests.

![image](https://user-images.githubusercontent.com/1093654/132944554-4ecac666-fdf6-4d0f-8e24-dd1b135f4511.png)

Thanks again for your great work;-D.