### PR TITLE
[PHP] Use roadrunner 2.x

### DIFF
--- a/php/chubbyphp-roadrunner/.rr.yaml
+++ b/php/chubbyphp-roadrunner/.rr.yaml
@@ -1,4 +1,4 @@
 http:
   address: :3000
-  workers:
-    command: "php public/index.php"
+server:
+  command: "php public/index.php"

--- a/php/chubbyphp-roadrunner/composer.json
+++ b/php/chubbyphp-roadrunner/composer.json
@@ -3,6 +3,6 @@
     "chubbyphp/chubbyphp-framework": "~4.0.0",
     "chubbyphp/chubbyphp-framework-router-fastroute": "*",
     "slim/psr7": "*",
-    "spiral/roadrunner": "*"
+    "spiral/roadrunner": "^2.0"
   }
 }

--- a/php/chubbyphp-roadrunner/composer.json
+++ b/php/chubbyphp-roadrunner/composer.json
@@ -3,6 +3,6 @@
     "chubbyphp/chubbyphp-framework": "~4.0.0",
     "chubbyphp/chubbyphp-framework-router-fastroute": "*",
     "slim/psr7": "*",
-    "spiral/roadrunner": "^2.0"
+    "spiral/roadrunner": "*"
   }
 }

--- a/php/chubbyphp-roadrunner/config.yaml
+++ b/php/chubbyphp-roadrunner/config.yaml
@@ -2,7 +2,10 @@ framework:
   github: chubbyphp/chubbyphp-framework
   version: 4.0
 
+php_mod:
+    - sockets
+
 before_command:
-  - vendor/bin/rr get-binary
+  - vendor/bin/rr get-binary --filter=v2.4
 
 command: ./rr serve

--- a/php/chubbyphp-roadrunner/config.yaml
+++ b/php/chubbyphp-roadrunner/config.yaml
@@ -6,6 +6,6 @@ php_mod:
     - sockets
 
 before_command:
-  - vendor/bin/rr get-binary --filter=v2.4
+  - ./vendor/bin/rr get-binary
 
 command: ./rr serve

--- a/php/chubbyphp-roadrunner/config.yaml
+++ b/php/chubbyphp-roadrunner/config.yaml
@@ -3,7 +3,11 @@ framework:
   version: 4.0
 
 php_mod:
-    - sockets
+  - sodium
+  - sockets
+
+deps:
+  - libsodium-dev
 
 before_command:
   - ./vendor/bin/rr get-binary

--- a/php/chubbyphp-roadrunner/public/index.php
+++ b/php/chubbyphp-roadrunner/public/index.php
@@ -11,11 +11,12 @@ use Chubbyphp\Framework\RequestHandler\CallbackRequestHandler;
 use Chubbyphp\Framework\Router\FastRoute\RouteMatcher;
 use Chubbyphp\Framework\Router\Route;
 use Chubbyphp\Framework\Router\Routes;
-use Psr\Http\Message\ServerRequestInterface;
 use Slim\Psr7\Factory\ResponseFactory;
-use Spiral\Goridge\StreamRelay;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Factory\StreamFactory;
+use Slim\Psr7\Factory\UploadedFileFactory;
+use Spiral\RoadRunner\Http\PSR7Worker;
 use Spiral\RoadRunner\Worker;
-use Spiral\RoadRunner\PSR7Client;
 
 ini_set('display_errors', 'stderr');
 
@@ -53,13 +54,17 @@ $app = new Application([
     ]), sys_get_temp_dir() . '/chubbyphp-roadrunner.php'), $responseFactory),
 ]);
 
-$worker = new Worker(new StreamRelay(STDIN, STDOUT));
-$psr7 = new PSR7Client($worker);
+$worker = new PSR7Worker(
+    Worker::create(),
+    new ServerRequestFactory(),
+    new StreamFactory(),
+    new UploadedFileFactory()
+);
 
-while ($req = $psr7->acceptRequest()) {
+while ($req = $worker->waitRequest()) {
     try {
-        $psr7->respond($app->handle($req));
+        $worker->respond($app->handle($req));
     } catch (\Throwable $e) {
-        $psr7->getWorker()->error((string)$e);
+        $worker->getWorker()->error((string)$e);
     }
 }

--- a/php/chubbyphp-roadrunner/public/index.php
+++ b/php/chubbyphp-roadrunner/public/index.php
@@ -11,6 +11,7 @@ use Chubbyphp\Framework\RequestHandler\CallbackRequestHandler;
 use Chubbyphp\Framework\Router\FastRoute\RouteMatcher;
 use Chubbyphp\Framework\Router\Route;
 use Chubbyphp\Framework\Router\Routes;
+use Psr\Http\Message\ServerRequestInterface;
 use Slim\Psr7\Factory\ResponseFactory;
 use Slim\Psr7\Factory\ServerRequestFactory;
 use Slim\Psr7\Factory\StreamFactory;

--- a/php/slim-roadrunner/.rr.yaml
+++ b/php/slim-roadrunner/.rr.yaml
@@ -1,4 +1,4 @@
 http:
   address: :3000
-  workers:
-    command: "php public/index.php"
+server:
+  command: "php public/index.php"

--- a/php/slim-roadrunner/config.yaml
+++ b/php/slim-roadrunner/config.yaml
@@ -6,6 +6,6 @@ php_mod:
   - sockets
   
 before_command:
-  - vendor/bin/rr get-binary --filter=v2.4
+  - ./vendor/bin/rr get-binary
 
 command: ./rr serve

--- a/php/slim-roadrunner/config.yaml
+++ b/php/slim-roadrunner/config.yaml
@@ -2,7 +2,10 @@ framework:
   website: slimframework.com
   version: 4.9
 
+php_mod:
+  - sockets
+  
 before_command:
-  - vendor/bin/rr get-binary
+  - vendor/bin/rr get-binary --filter=v2.4
 
 command: ./rr serve

--- a/php/slim-roadrunner/config.yaml
+++ b/php/slim-roadrunner/config.yaml
@@ -2,7 +2,11 @@ framework:
   website: slimframework.com
   version: 4.9
 
+build_deps:
+  - libsodium-dev
+
 php_mod:
+  - sodium
   - sockets
   
 before_command:

--- a/php/sunrise-router-roadrunner/composer.json
+++ b/php/sunrise-router-roadrunner/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "spiral/roadrunner": "^2.0",
+    "spiral/roadrunner": "~1.0",
     "sunrise/http-router": "~2.11.0",
     "sunrise/http-factory": "*"
   }

--- a/php/sunrise-router-roadrunner/composer.json
+++ b/php/sunrise-router-roadrunner/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "spiral/roadrunner": "~1.0",
+    "spiral/roadrunner": "*",
     "sunrise/http-router": "~2.11.0",
     "sunrise/http-factory": "*"
   }

--- a/php/sunrise-router-roadrunner/config.yaml
+++ b/php/sunrise-router-roadrunner/config.yaml
@@ -14,6 +14,6 @@ php_ext:
 
 before_command:
   - composer update
-  - ./vendor/bin/rr get-binary --filter=v2.4
+  - ./vendor/bin/rr get-binary
 
 command: ./rr serve

--- a/php/sunrise-router-roadrunner/config.yaml
+++ b/php/sunrise-router-roadrunner/config.yaml
@@ -14,6 +14,6 @@ php_ext:
 
 before_command:
   - composer update
-  - ./vendor/bin/rr get-binary
+  - ./vendor/bin/rr get-binary --filter=v2.4
 
 command: ./rr serve

--- a/php/sunrise-router-roadrunner/config.yaml
+++ b/php/sunrise-router-roadrunner/config.yaml
@@ -5,9 +5,6 @@ framework:
 build_deps:
   - libevent-dev
 
-php_mod:
-  - sockets
-
 php_ext:
   - event
   - apcu

--- a/php/sunrise-router-roadrunner/config.yaml
+++ b/php/sunrise-router-roadrunner/config.yaml
@@ -4,13 +4,17 @@ framework:
 
 build_deps:
   - libevent-dev
+  - libsodium-dev
+
+php_mod:
+  - sodium
+  - sockets
 
 php_ext:
   - event
   - apcu
 
 before_command:
-  - composer update
   - ./vendor/bin/rr get-binary
 
 command: ./rr serve


### PR DESCRIPTION
Hi,

The last version of `roarunner` is unusable on **alpine**

However, the previous version (**2.4**) works.

Regards,