### PR TITLE
[C#] Fix BeetleX version

### DIFF
--- a/csharp/beetlex/config.yaml
+++ b/csharp/beetlex/config.yaml
@@ -1,4 +1,4 @@
 framework:
   website: beetlex.io
   github: beetlex-io
-  version: 2.0
+  version: 1.8

--- a/csharp/beetlex/web.csproj
+++ b/csharp/beetlex/web.csproj
@@ -7,8 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeetleX.FastHttpApi" Version="2.0.*" />
-    <PackageReference Include="BeetleX.FastHttpApi.Hosting" Version="1.5.*" />
+    <PackageReference Include="BeetleX" Version="1.8.*" />
+    <PackageReference Include="BeetleX.FastHttpApi" Version="*" />
+    <PackageReference Include="BeetleX.FastHttpApi.Hosting" Version="*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi @beetlex-io,

As I understand, `fasthttpapi` has been yanked. Thus we are facing an error **NU1605**
https://github.com/the-benchmarker/web-frameworks/runs/4753249621?check_suite_focus=true#step:6:59

Regards,