### PR TITLE
[fastendpoints] disable logging providers

### DIFF
--- a/csharp/fastendpoints/Program.cs
+++ b/csharp/fastendpoints/Program.cs
@@ -1,6 +1,7 @@
-﻿using FastEndpoints;
+using FastEndpoints;
 
 var builder = WebApplication.CreateBuilder();
+builder.Logging.ClearProviders(); //logging results in a ~95% perf drop
 builder.Services.AddFastEndpoints();
 
 var app = builder.Build();


### PR DESCRIPTION
default logging settings result in about a %95 performance drop when benchmarking.