### PR TITLE
Added HyperExpress webserver

### DIFF
--- a/javascript/hyper-express/app.js
+++ b/javascript/hyper-express/app.js
@@ -1,0 +1,25 @@
+const HyperExpress = require('hyper-express');
+
+// Create a new instance of HyperExpress HTTP
+const port = 3000;
+const app = new HyperExpress.Server();
+
+// GET "/" => 200 with empty body
+app.get('/', (request, response) => {
+    response.send('');
+});
+
+// GET "/user/:id" => 200 with "id" as body
+app.get('/user/:id', (request, response) => {
+    response.send(request.path_parameters.id);
+});
+
+// POST "/user" => 200 with empty body
+app.post('/user', (request, response) => {
+    response.send('');
+});
+
+// Start the server on port 3000
+app.listen(port)
+    .then(() => console.log(`Started HyperExpress on port ${port}`))
+    .catch((error) => console.log(`Failed to start HyperExpress on port ${port} because: ${error}`));

--- a/javascript/hyper-express/app.js
+++ b/javascript/hyper-express/app.js
@@ -20,6 +20,4 @@ app.post('/user', (request, response) => {
 });
 
 // Start the server on port 3000
-app.listen(port)
-    .then(() => console.log(`Started HyperExpress on port ${port}`))
-    .catch((error) => console.log(`Failed to start HyperExpress on port ${port} because: ${error}`));
+app.listen(port);

--- a/javascript/hyper-express/config.yaml
+++ b/javascript/hyper-express/config.yaml
@@ -1,0 +1,9 @@
+framework:
+  github: kartikk221/hyper-express
+  version: 6.0
+
+build_deps:
+  - git # required by uWebSockets.js
+
+bin_deps:
+  - gcompat # required by uWebSockets.js

--- a/javascript/hyper-express/config.yaml
+++ b/javascript/hyper-express/config.yaml
@@ -1,6 +1,6 @@
 framework:
   github: kartikk221/hyper-express
-  version: 6.0
+  version: 6.1
 
 build_deps:
   - git # required by uWebSockets.js

--- a/javascript/hyper-express/package.json
+++ b/javascript/hyper-express/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "hyper-express": "^6.1.3"
+        "hyper-express": "~6.1.3"
     }
 }

--- a/javascript/hyper-express/package.json
+++ b/javascript/hyper-express/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "hyper-express": "^6.1.3"
+    }
+}

--- a/reviewers.yaml
+++ b/reviewers.yaml
@@ -17,6 +17,8 @@ javascript:
     - dominikzogg
   chubbyjs-uwebsockets:
     - dominikzogg
+  hyper-express:
+    - kartikk221
 go:
   router:
     - savsgio


### PR DESCRIPTION
Hello, this is the PR to add HyperExpress support as discussed in issue #5319 

I simply initialized the HyperExpress application to serve requests on the 3 endpoints specified in the issue.

HyperExpress is built on top of uWebsockets.js like some other webservers hence I also included the following:
```yaml
build_deps:
  - git # required by uWebSockets.js

bin_deps:
  - gcompat # required by uWebSockets.js
```

------
Closes #5319 