### PR TITLE
Upgrade Athena to `0.17.x`

### DIFF
--- a/crystal/Dockerfile
+++ b/crystal/Dockerfile
@@ -6,6 +6,10 @@ COPY . ./
 
 RUN apk add --update yaml-static
 
+{{#build_deps}}
+RUN apk add --update {{{.}}}
+{{/build_deps}}
+
 RUN shards lock
 RUN shards install --production
 RUN shards build --release --no-debug --static {{#build_opts}} {{{.}}} {{/build_opts}}

--- a/crystal/athena/config.yaml
+++ b/crystal/athena/config.yaml
@@ -1,6 +1,9 @@
 framework:
   github: athena-framework/athena
-  version: 0.15
+  version: 0.17
+
+build_deps:
+  - pcre2-dev
 
 environment:
   ATHENA_ENV: production

--- a/crystal/athena/shard.yml
+++ b/crystal/athena/shard.yml
@@ -10,7 +10,7 @@ targets:
 
 dependencies:
   athena:
-    github: athena-framework/athena
-    version: ~> 0.15.0
+    github: athena-framework/framework
+    version: ~> 0.17.0
 
 license: MIT

--- a/crystal/athena/src/server.cr
+++ b/crystal/athena/src/server.cr
@@ -3,16 +3,15 @@ require "athena"
 Log.setup :none
 
 class BenchmarkController < ATH::Controller
-  @[ATHA::Get("/")]
+  @[ARTA::Get("/")]
   def root_get : Nil
   end
 
-  @[ATHA::Post("/user")]
+  @[ARTA::Post("/user")]
   def root_post : Nil
-    
   end
 
-  @[ATHA::Get("/user/:id", constraints: {id: /\d+/})]
+  @[ARTA::Get("/user/{id<\\d+>}")]
   def user(id : Int32) : Int32
     id
   end

--- a/nim/basolato/.gitignore
+++ b/nim/basolato/.gitignore
@@ -3,6 +3,9 @@
 !*.*
 !*/
 
+.Dockerfile
+.Makefile
+
 # Test coverage
 coverage/*
 lcov.info


### PR DESCRIPTION
Had to add the ability for Crystal frameworks to add extra dependencies to the built image given Athena requires `pcre2` while the stdlib only uses `pcre1`.

I also added the generated Makefile and Dockerfile to `.gitignore` for a nim lang as it otherwise was being tracked.