### PR TITLE
Fix fsharp giraffe benchmarks

### DIFF
--- a/fsharp/giraffe-endpoints/Program.fs
+++ b/fsharp/giraffe-endpoints/Program.fs
@@ -2,6 +2,7 @@ open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Hosting
+open Microsoft.Extensions.Logging
 open Giraffe
 open Giraffe.EndpointRouting
 
@@ -24,6 +25,10 @@ let configureApp (app: IApplicationBuilder) =
         .UseEndpoints(fun e -> e.MapGiraffeEndpoints(webApp))
     |> ignore
 
+let configureLogging (log : ILoggingBuilder) =
+    log.ClearProviders()
+    |> ignore
+
 let configureServices (services: IServiceCollection) = services.AddRouting() |> ignore
 
 let args = System.Environment.GetCommandLineArgs()
@@ -33,6 +38,7 @@ Host
     .ConfigureWebHost(fun webHost ->
         webHost
             .UseKestrel()
+            .ConfigureLogging(configureLogging)
             .ConfigureServices(configureServices)
             .Configure(configureApp)
         |> ignore)

--- a/fsharp/giraffe/Program.fs
+++ b/fsharp/giraffe/Program.fs
@@ -3,6 +3,7 @@ open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Hosting
+open Microsoft.Extensions.Logging
 open Giraffe
 
 // ---------------------------------
@@ -21,6 +22,10 @@ let webApp: HttpFunc -> HttpFunc =
 
 let configureApp (app: IApplicationBuilder) = app.UseGiraffe(webApp)
 
+let configureLogging (log : ILoggingBuilder) =
+    log.ClearProviders()
+    |> ignore
+
 let configureServices (services: IServiceCollection) = services.AddGiraffe() |> ignore
 
 let args = System.Environment.GetCommandLineArgs()
@@ -28,6 +33,7 @@ let args = System.Environment.GetCommandLineArgs()
 Host.CreateDefaultBuilder(args)
     .ConfigureWebHost(fun webHost ->
         webHost.UseKestrel()
+                .ConfigureLogging(configureLogging)
                 .ConfigureServices(configureServices)
                 .Configure(Action<IApplicationBuilder> configureApp)
                 |> ignore)


### PR DESCRIPTION
This commit aims to rectify oddities in the fsharp giraffe benchmarks (giraffe, giraffe-endpoints) that likely led to its unusually poor results.

The fix to each is to clear the default logging providers - presumably this removes a good amount of processing / IO which leads to better request / response performance.

## Why is this okay? Is this cheating?

I believe this is okay because this seems to be the standard for dotnet benchmarks (fsharp and csharp) - both in this repo and in others (like tech empower). 

It is a little sus (idk if other languages are doing this) but it will at least get these benchmarks in parity with others on the same tech stack.

fsharp:

- Falco - clears - https://github.com/the-benchmarker/web-frameworks/blob/master/fsharp/falco/Program.fs#L11
- Saturn - clears - https://github.com/the-benchmarker/web-frameworks/blob/master/fsharp/saturn/Program.fs#L19
- frank - clears - https://github.com/the-benchmarker/web-frameworks/blob/master/fsharp/frank/Program.fs#L31
- suave - not sure - https://github.com/the-benchmarker/web-frameworks/blob/master/fsharp/suave/Program.fs
- websharper - clears - https://github.com/the-benchmarker/web-frameworks/blob/master/fsharp/websharper/Main.fs#L44

csharp:

aspnet-minimal-api - clears - https://github.com/the-benchmarker/web-frameworks/blob/master/fsharp/websharper/Main.fs#L44 

tech empower

- giraffe in tech empower also clears - https://github.com/TechEmpower/FrameworkBenchmarks/blob/master/frameworks/FSharp/giraffe/src/App/Program.fs#L140

References
- @panesofglass benchmark perf questions - https://github.com/giraffe-fsharp/Giraffe/issues/529 