### PR TITLE
[fsharp][giraffe] Improve benchmark by configuring kestrel

### DIFF
--- a/fsharp/giraffe-endpoints/Program.fs
+++ b/fsharp/giraffe-endpoints/Program.fs
@@ -37,7 +37,7 @@ Host
     .CreateDefaultBuilder(args)
     .ConfigureWebHost(fun webHost ->
         webHost
-            .UseKestrel()
+            .UseKestrel(fun c -> c.AddServerHeader <- false)
             .ConfigureLogging(configureLogging)
             .ConfigureServices(configureServices)
             .Configure(configureApp)

--- a/fsharp/giraffe/Program.fs
+++ b/fsharp/giraffe/Program.fs
@@ -32,7 +32,7 @@ let args = System.Environment.GetCommandLineArgs()
 
 Host.CreateDefaultBuilder(args)
     .ConfigureWebHost(fun webHost ->
-        webHost.UseKestrel()
+        webHost.UseKestrel(fun c -> c.AddServerHeader <- false)
                 .ConfigureLogging(configureLogging)
                 .ConfigureServices(configureServices)
                 .Configure(Action<IApplicationBuilder> configureApp)


### PR DESCRIPTION
This PR aims to further even the dotnet playing field by configuring [giraffe, giraffe-endpoints] with a common benchmark optimization for dotnet projects: removing Kestrel's server header.

### Other dotnet web frameworks doing this

* WebSharper - https://github.com/the-benchmarker/web-frameworks/blob/master/fsharp/websharper/Main.fs#L43 
* Falco - https://github.com/the-benchmarker/web-frameworks/blob/master/fsharp/falco/Program.fs#L25

### References

This is a followup to https://github.com/the-benchmarker/web-frameworks/pull/5929 