### PR TITLE
[FSharp][Giraffe / Giraffe-endpoints] Update giraffe to 6.0

### DIFF
--- a/fsharp/giraffe-endpoints/config.yaml
+++ b/fsharp/giraffe-endpoints/config.yaml
@@ -1,3 +1,3 @@
 framework:
   github: giraffe-fsharp/Giraffe
-  version: 5.0
+  version: 6.0

--- a/fsharp/giraffe-endpoints/web.fsproj
+++ b/fsharp/giraffe-endpoints/web.fsproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="7.0.*" />
-    <PackageReference Include="Giraffe" Version="5.0.*" />
+    <PackageReference Include="Giraffe" Version="6.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/fsharp/giraffe/config.yaml
+++ b/fsharp/giraffe/config.yaml
@@ -1,3 +1,3 @@
 framework:
   github: giraffe-fsharp/Giraffe
-  version: 5.0
+  version: 6.0

--- a/fsharp/giraffe/web.fsproj
+++ b/fsharp/giraffe/web.fsproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="7.0.*" />
-    <PackageReference Include="Giraffe" Version="5.0.*" />
+    <PackageReference Include="Giraffe" Version="6.0.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Giraffe has been on its 6.0 release since mid 2022, so updating it here as well.

Giraffe repo: https://github.com/giraffe-fsharp/Giraffe 

# Testing

Ran both locally with `dotnet run`