### PR TITLE
[fsharp][suave] Remove logger IO in Suave to improve performance

### DIFF
--- a/fsharp/suave/Program.fs
+++ b/fsharp/suave/Program.fs
@@ -1,5 +1,6 @@
 open Suave
 open Suave.Filters
+open Suave.Logging
 open Suave.Operators
 open System.Net
 
@@ -10,12 +11,23 @@ let app: WebPart =
                         pathScan "/user/%s" (fun s -> Successful.OK s) ]
           POST >=> path "/user" >=> Successful.OK "" ]
 
+type NoopLogger() = 
+    interface Logger with 
+        member this.name : string[] = [|"null-logger"|]
+        member this.logWithAck (logLevel : LogLevel) (logLevelWithMessage : (LogLevel -> Message)): Async<unit> =
+            async {
+                ()
+            }
+        member this.log (loglevel : LogLevel) (logLevelWithMessage : (LogLevel -> Message)): unit = 
+            ()
+
 let config =
     { defaultConfig with
         bindings =
             [ { scheme = HTTP
                 socketBinding =
                     { ip = IPAddress.Parse "0.0.0.0"
-                      port = 3000us } } ] }
+                      port = 3000us } } ];
+        logger = NoopLogger()}
 
 startWebServer config app


### PR DESCRIPTION
# Overview

I'm removing the default logger from Suave by using its built-in [Logger interface](https://github.com/SuaveIO/suave/blob/57d69e39e67a5b1a1c60b7c015c698a1901a9420/src/Suave/Utils/Logging.fs#L178) (see [docs](https://github.com/SuaveIO/suave/blob/57d69e39e67a5b1a1c60b7c015c698a1901a9420/docs/api.md))

I expect this to improve Suave's performance considerably and make this a better comparison against other fsharp frameworks.

# Context

* Problem: [I noticed that Suave was performing terribly](https://hamy.xyz/labs/2023-01-top-fsharp-backend-frameworks) - a negative outlier 
* It seems that Suave has default logging enabled when using the defaultConfig
* Solution: Remove logging

Note: I made [a similar PR to the Giraffe benchmark](https://github.com/the-benchmarker/web-frameworks/pull/5929) a few months ago and it seemed to work resulting in [6.5x improvement in benchmark](https://hamy.xyz/labs/2022-12-improving-fsharp-giraffe-web-benchmarks).

# Testing

* Ran Suave locally with dotnet run -> confirmed server runs as expected