### PR TITLE
[Scala] Use sbt official docker images

### DIFF
--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:11.0.13_1.6.1_2.13.8 AS build
+FROM sbtscala/scala-sbt:eclipse-temurin-17.0.4_1.7.1_2.13.10 AS build
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
This `PR` switch the current docker images to https://github.com/sbt/docker-sbt.

The idea is to :
+ allow using 2.x and 3.x
+ use more official images

However, it is https://projects.eclipse.org/projects/adoptium.temurin and I have to admit, I'm loss about all java platforms.