### PR TITLE
PHP/Antidot: Run with xdebug mode off and allow using cached config

### DIFF
--- a/php/antidot/config.yaml
+++ b/php/antidot/config.yaml
@@ -1,12 +1,14 @@
 language:
   engines:
     reactphp:
-      command: bin/console serve
+      command: XDEBUG_MODE=off bin/console serve
 
 framework:
   website: antidotfw.io
   github: antidot-framework/antidot-framework
   version: 2.0
+  bootstrap:
+    - mkdir -p var/cache
 
   files:
     - "**/*.php"


### PR DESCRIPTION
Hi @waghanza I want to try running the same command with XDEBUG_MODE=off environment variable, I'm obtaining much better response times locally.

Also I added cache directory, to allow the framework creating the cached config file.

Thanks again for the great work you are doing :raised_hands::raised_hands::raised_hands: 