### PR TITLE
Changed the deprecated `Process.fork` to the supported `Process.exec`

### DIFF
--- a/crystal/amber/src/amber.cr
+++ b/crystal/amber/src/amber.cr
@@ -2,9 +2,11 @@ require "../config/*"
 
 Amber.env = "production"
 
-System.cpu_count.times do |i|
-  Process.fork do
-    Amber::Server.start
+if ARGV.size > 0 && ARGV[0] == "--start-amber"
+  Amber::Server.start
+else
+  System.cpu_count.times do |i|
+    Process.exec("amber", ["--start-amber"])
   end
 end
 

--- a/crystal/amber/src/controllers/application_controller.cr
+++ b/crystal/amber/src/controllers/application_controller.cr
@@ -3,7 +3,7 @@ class ApplicationController < Amber::Controller::Base
   end
 
   def get
-    return params[:id]
+    params[:id]
   end
 
   def create


### PR DESCRIPTION
- Removed the unnecessary explicit 'return'
- Changed from the deprecated `Process.fork` to `Process.exec` with a bit of recursiveness that should accomplish the same thing