### PR TITLE
Production flags

### DIFF
--- a/d/vibed/config.yaml
+++ b/d/vibed/config.yaml
@@ -1,6 +1,3 @@
 framework:
   website: vibed.org
   version: 0.9
-
-deps:
-  - openssl

--- a/d/vibed/dub.json
+++ b/d/vibed/dub.json
@@ -1,0 +1,17 @@
+{
+	"name": "server",
+	"dependencies": {
+		"vibe-d:http": "~>0.9.7"
+	},
+    "versions": [
+        "VibeManualMemoryManagement",
+        "VibeHighEventPriority",
+        "VibeDisableCommandLineParsing"
+    ],
+    "dflags-ldc": [
+        "-mcpu=native",
+        "-flto=thin",
+        "-flto-binary=/usr/lib/LLVMgold.so"
+    ],
+	"license": "MIT"
+}

--- a/d/vibed/dub.sdl
+++ b/d/vibed/dub.sdl
@@ -1,6 +1,0 @@
-name "server"
-license "MIT"
-versions "VibeNoSSL"
-dependency "vibe-d:web" version="~>0.9.6"
-dependency "vibe-d:tls" version="~>0.9.6"
-subConfiguration "vibe-d:tls" "notls"

--- a/nim/Dockerfile
+++ b/nim/Dockerfile
@@ -27,9 +27,7 @@ ENV PATH $PATH:/root/.nimble/bin
 {{/build_command}}
 {{^build_command}}
   RUN nim c {{#build_opts}} {{{.}}} {{/build_opts}} \
-    --excessiveStackTrace:off \
     --assertions:off \
-    --checks:off \
     --warnings:off \
     --hints:off \
     -d:release \

--- a/rust/actix/Cargo.toml
+++ b/rust/actix/Cargo.toml
@@ -14,7 +14,6 @@ actix-web = "4.4"
 opt-level = 3
 debug = false
 debug-assertions = false
-overflow-checks = false
 lto = true
 panic = "abort"
 incremental = false

--- a/rust/axum/Cargo.toml
+++ b/rust/axum/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 opt-level = 3
 debug = false
 debug-assertions = false
-overflow-checks = false
 lto = true
 panic = "abort"
 incremental = false

--- a/rust/gotham/Cargo.toml
+++ b/rust/gotham/Cargo.toml
@@ -13,7 +13,6 @@ serde = { version = "1.0", features = ["derive"] }
 opt-level = 3
 debug = false
 debug-assertions = false
-overflow-checks = false
 lto = true
 panic = "abort"
 incremental = false

--- a/rust/graphul/Cargo.toml
+++ b/rust/graphul/Cargo.toml
@@ -12,7 +12,6 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 opt-level = 3
 debug = false
 debug-assertions = false
-overflow-checks = false
 lto = true
 panic = "abort"
 incremental = false

--- a/rust/iron/Cargo.toml
+++ b/rust/iron/Cargo.toml
@@ -13,7 +13,6 @@ router = "0.6"
 opt-level = 3
 debug = false
 debug-assertions = false
-overflow-checks = false
 lto = true
 panic = "abort"
 incremental = false

--- a/rust/nickel/Cargo.toml
+++ b/rust/nickel/Cargo.toml
@@ -12,7 +12,6 @@ nickel = "0.11"
 opt-level = 3
 debug = false
 debug-assertions = false
-overflow-checks = false
 lto = true
 panic = "abort"
 incremental = false

--- a/rust/oxidy/Cargo.toml
+++ b/rust/oxidy/Cargo.toml
@@ -11,7 +11,6 @@ debug = true
 opt-level = 3
 debug = false
 debug-assertions = false
-overflow-checks = false
 lto = true
 panic = "abort"
 incremental = false

--- a/rust/poem/Cargo.toml
+++ b/rust/poem/Cargo.toml
@@ -11,7 +11,6 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 opt-level = 3
 debug = false
 debug-assertions = false
-overflow-checks = false
 lto = true
 panic = "abort"
 incremental = false

--- a/rust/rocket/Cargo.toml
+++ b/rust/rocket/Cargo.toml
@@ -10,7 +10,6 @@ rocket = "0.5.0-rc"
 opt-level = 3
 debug = false
 debug-assertions = false
-overflow-checks = false
 lto = true
 panic = "abort"
 incremental = false

--- a/rust/salvo/Cargo.toml
+++ b/rust/salvo/Cargo.toml
@@ -12,7 +12,6 @@ tokio = { version = "1", features = ["full"] }
 opt-level = 3
 debug = false
 debug-assertions = false
-overflow-checks = false
 lto = true
 panic = "abort"
 incremental = false

--- a/rust/silent/Cargo.toml
+++ b/rust/silent/Cargo.toml
@@ -11,7 +11,6 @@ silent = { version = "0.11" }
 opt-level = 3
 debug = false
 debug-assertions = false
-overflow-checks = false
 lto = true
 panic = "abort"
 incremental = false

--- a/rust/tide/Cargo.toml
+++ b/rust/tide/Cargo.toml
@@ -11,7 +11,6 @@ opt-level = 0
 opt-level = 3
 debug = false
 debug-assertions = false
-overflow-checks = false
 lto = true
 panic = "abort"
 incremental = false

--- a/rust/viz/Cargo.toml
+++ b/rust/viz/Cargo.toml
@@ -12,7 +12,6 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 opt-level = 3
 debug = false
 debug-assertions = false
-overflow-checks = false
 lto = true
 panic = "abort"
 incremental = false

--- a/rust/warp/Cargo.toml
+++ b/rust/warp/Cargo.toml
@@ -11,7 +11,6 @@ opt-level = 0
 opt-level = 3
 debug = false
 debug-assertions = false
-overflow-checks = false
 lto = true
 panic = "abort"
 incremental = false


### PR DESCRIPTION
As it was mentioned https://github.com/the-benchmarker/web-frameworks/issues/6374
Remove some potentially danger flags for production environment.

Not sure about the other flags. I suppose for real production even less flags could be used, but at least some bounds-check should be remain.