### PR TITLE
Updated the Amber test command 

### DIFF
--- a/crystal/amber/src/amber.cr
+++ b/crystal/amber/src/amber.cr
@@ -6,7 +6,7 @@ if ARGV.size > 0 && ARGV[0] == "--start-amber"
   Amber::Server.start
 else
   System.cpu_count.times do |i|
-    Process.exec("amber", ["--start-amber"])
+    Process.new("/usr/bin/app", ["--start-amber"])
   end
 end
 


### PR DESCRIPTION
It now uses the 'app' binary name that the default docker file uses.

I still can't run this locally since I'm on an M1, which is a total bummer that Virtualbox doesn't work on M1 arch 😭