### PR TITLE
fix `Bun.serve` command for Hono

### DIFF
--- a/javascript/hono/app.ts
+++ b/javascript/hono/app.ts
@@ -5,4 +5,8 @@ app.get("/", (c) => c.text(""));
 app.get("/user/:id", (c) => c.text(c.req.param("id")));
 app.post("/user", (c) => c.text(""));
 
-export default app;
+Bun.serve({
+  fetch: app.fetch,
+  reusePort: true,
+  port: 3000
+})


### PR DESCRIPTION
Hi.

In this PR, I've changed the entry point of Hono app. Without the `reusePort: true` option, we get a duplicate port error when starting with pm2.

The errors:

<img width="935" alt="Screenshot 2023-10-01 at 22 26 50" src="https://github.com/the-benchmarker/web-frameworks/assets/10682/1118336c-151b-417f-b6ac-711dd05f9ea2">

When I run the `pm2 list` command, a process other than one fails:

<img width="1290" alt="Screenshot 2023-10-01 at 22 27 11" src="https://github.com/the-benchmarker/web-frameworks/assets/10682/83a26c8f-a494-468a-a532-75a243b372a6">

I haven't tried this to see how much it affects performance, but it would fix the problem of forking. Thanks!
