### PR TITLE
Ensure .NET workloads use Server GC and enable inline sockets completion

### DIFF
--- a/csharp/Dockerfile
+++ b/csharp/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 COPY *.csproj .
 RUN dotnet restore
 
-# copy everything else and build app
+# copy everything else and build app 
 COPY . .
 RUN dotnet publish -c release -o out
 

--- a/csharp/config.yaml
+++ b/csharp/config.yaml
@@ -10,6 +10,9 @@ language:
       command: dotnet /usr/src/app/out/web.dll
       environment:
         ASPNETCORE_URLS: http://*:3000
+        DOTNET_gcServer: 1
+        DOTNET_SYSTEM_NET_SOCKETS_INLINE_COMPLETIONS: 1
+        DOTNET_Thread_UseAllCpuGroups: 1
 
 framework:
   engines:


### PR DESCRIPTION
This should significantly improve throughput (if wasn't enabled previously) by using throughput-optimized GC (it is a commonly used default for server deployments).

Additionally enables inline socket completion - if Java workloads get to do this, we get to do this too.