### PR TITLE
Aligning hertz configuration items with gofiber

### DIFF
--- a/go/fiber/main.go
+++ b/go/fiber/main.go
@@ -19,13 +19,11 @@ var (
 
 func main() {
 	app := fiber.New(fiber.Config{
-		Prefork:                   false,
-		CaseSensitive:             true,
-		StrictRouting:             true,
-		DisableDefaultDate:        true,
-		DisableStartupMessage:     true,
-		DisableHeaderNormalizing:  true,
-		DisableDefaultContentType: true,
+		Prefork:                  false,
+		CaseSensitive:            true,
+		StrictRouting:            true,
+		DisableStartupMessage:    true,
+		DisableHeaderNormalizing: true,
 	})
 
 	app.Get("/", handlerOK)

--- a/go/hertz/main.go
+++ b/go/hertz/main.go
@@ -12,6 +12,8 @@ func main() {
 		server.WithHostPorts(":3000"),
 		server.WithDisableHeaderNamesNormalizing(true),
 		server.WithDisablePrintRoute(true),
+		server.WithDisableDefaultDate(true),
+		server.WithDisableDefaultContentType(true),
 	)
 
 	r.GET("/", func(_ context.Context, ctx *app.RequestContext) {})

--- a/go/hertz/main.go
+++ b/go/hertz/main.go
@@ -12,8 +12,6 @@ func main() {
 		server.WithHostPorts(":3000"),
 		server.WithDisableHeaderNamesNormalizing(true),
 		server.WithDisablePrintRoute(true),
-		server.WithDisableDefaultDate(true),
-		server.WithDisableDefaultContentType(true),
 	)
 
 	r.GET("/", func(_ context.Context, ctx *app.RequestContext) {})


### PR DESCRIPTION
### Description

In `hertz` 0.7.2, the `disableDate` and `disableContentType` configuration options have been added.

This commit aims to bring hertz configuration closer to gofiber.