### PR TITLE
Use `UNARY` type for Armeria `HttpService`

### DIFF
--- a/java/armeria/src/main/java/benchmark/armeria/BenchmarkApplication.java
+++ b/java/armeria/src/main/java/benchmark/armeria/BenchmarkApplication.java
@@ -1,24 +1,37 @@
 package benchmark.armeria;
 
+import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Route;
+import com.linecorp.armeria.server.RoutingContext;
 import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServiceRequestContext;
 
 public class BenchmarkApplication {
 
     public static void main(String... args) {
         final Server server = Server.builder()
                 .http(3000)
-                .service("/", (ctx, req) -> HttpResponse.of(""))
-                .service("/user/:userId", (ctx, req) -> HttpResponse.of(ctx.pathParam("userId")))
+                .service("/", (UnaryService) (ctx, req) -> HttpResponse.of(""))
+                .service("/user/:userId", (UnaryService) (ctx, req) -> HttpResponse.of(ctx.pathParam("userId")))
                 .service(Route.builder()
                         .path("/user")
                         .methods(HttpMethod.POST)
-                        .build(), (ctx, req) -> HttpResponse.of(""))
+                        .build(), (UnaryService) (ctx, req) -> HttpResponse.of(""))
                 .build();
 
         server.closeOnJvmShutdown();
         server.start().join();
+    }
+
+    @FunctionalInterface
+    private interface UnaryService extends HttpService {
+        @Override
+        default ExchangeType exchangeType(RoutingContext routingContext) {
+            return ExchangeType.UNARY;
+        }
     }
 }

--- a/java/armeria/src/main/java/benchmark/armeria/BenchmarkApplication.java
+++ b/java/armeria/src/main/java/benchmark/armeria/BenchmarkApplication.java
@@ -9,29 +9,36 @@ import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.RoutingContext;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Post;
 
 public class BenchmarkApplication {
 
     public static void main(String... args) {
         final Server server = Server.builder()
                 .http(3000)
-                .service("/", (UnaryService) (ctx, req) -> HttpResponse.of(""))
-                .service("/user/:userId", (UnaryService) (ctx, req) -> HttpResponse.of(ctx.pathParam("userId")))
-                .service(Route.builder()
-                        .path("/user")
-                        .methods(HttpMethod.POST)
-                        .build(), (UnaryService) (ctx, req) -> HttpResponse.of(""))
+                .annotatedService(new UserService())
                 .build();
 
         server.closeOnJvmShutdown();
         server.start().join();
     }
 
-    @FunctionalInterface
-    private interface UnaryService extends HttpService {
-        @Override
-        default ExchangeType exchangeType(RoutingContext routingContext) {
-            return ExchangeType.UNARY;
+    private static final class UserService {
+        @Get("/")
+        public String index() {
+            return "";
+        }
+
+        @Get("/user/:userId")
+        public String getUser(@Param("userId") String userId) {
+            return userId;
+        }
+
+        @Post("/user")
+        public String createUser() {
+            return "";
         }
     }
 }


### PR DESCRIPTION
The default `ExchangeType` for `HttpService` is `BIDI_STREAMING` which is not optimized for non-streaming / simple requests. `UNARY` type is suitable for the current benchmark.

In fact, `ExchangeType` is automatically inferred for annotated service, gRPC, and Thrift services so normal users don't need to set the type explicitly.