### PR TITLE
Remove thread compilation option

### DIFF
--- a/nim/Dockerfile
+++ b/nim/Dockerfile
@@ -49,7 +49,9 @@ WORKDIR /usr/src/app
 
 RUN apt-get -qq update
 
-RUN apt-get -qy install libssl-dev libpcre3-dev
+RUN apt-get -qy install \
+    libssl-dev \
+    libpcre3-dev
 
 {{#custom_files}}
   COPY --from=0 /usr/src/app/{{{.}}} /usr/src/app/{{{.}}}

--- a/nim/guildenstern/server.nim.cfg
+++ b/nim/guildenstern/server.nim.cfg
@@ -1,2 +1,1 @@
---threads:on
 --d:threadsafe

--- a/nim/httpbeast/server.nim.cfg
+++ b/nim/httpbeast/server.nim.cfg
@@ -1,1 +1,0 @@
---threads:on

--- a/nim/mike/server.nim.cfg
+++ b/nim/mike/server.nim.cfg
@@ -1,1 +1,0 @@
---threads:on

--- a/nim/scorper/server.nim.cfg
+++ b/nim/scorper/server.nim.cfg
@@ -1,1 +1,0 @@
---threads:on

--- a/nim/scorper/server.nim.cfg
+++ b/nim/scorper/server.nim.cfg
@@ -1,0 +1,1 @@
+--threads:off

--- a/nim/whip/server.nim.cfg
+++ b/nim/whip/server.nim.cfg
@@ -1,1 +1,0 @@
---threads:on


### PR DESCRIPTION
Hi @bung87 ,

After removing `thread:on`, `scorper` seems to perform better

```json
[
    {
      "level": 512,
      "label": "minimum_latency",
      "value": 3207.6666666666665,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "total_requests_per_s",
      "value": 2774.6666666666665,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "duration_ms",
      "value": 10017968.666666666,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "percentile_75",
      "value": 2143.3333333333335,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "percentile_99",
      "value": 77236.66666666667,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "socket_connection_errors",
      "value": 0,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "average_latency",
      "value": 6393,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "socket_read_errors",
      "value": 0,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "total_requests",
      "value": 49628.333333333336,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "total_bytes_received",
      "value": 6380200,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "socket_write_errors",
      "value": 0,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "total_requests",
      "value": 69350,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "percentile_99",
      "value": 2745.6666666666665,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "request_timeouts",
      "value": 44,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "total_bytes_received",
      "value": 3840785.3333333335,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "socket_connection_errors",
      "value": 0,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "percentile_90",
      "value": 2156,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "percentile_90",
      "value": 6241.333333333333,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "maximum_latency",
      "value": 152819.66666666666,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "standard_deviation",
      "value": 5515,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "percentile_50",
      "value": 20389.333333333332,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "total_bytes_received",
      "value": 4565806.666666667,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "maximum_latency",
      "value": 23599.666666666668,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "total_requests",
      "value": 41747.666666666664,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "socket_connection_errors",
      "value": 0,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "percentile_99.999",
      "value": 329640,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "percentile_99",
      "value": 25870.333333333332,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "socket_read_errors",
      "value": 21.333333333333332,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "percentile_50",
      "value": 5901.666666666667,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "percentile_75",
      "value": 6011.333333333333,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "standard_deviation",
      "value": 439,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "percentile_99.999",
      "value": 149897,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "average_latency",
      "value": 18724.333333333332,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "percentile_99.999",
      "value": 23125.333333333332,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "http_errors",
      "value": 0,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "socket_write_errors",
      "value": 12722.666666666666,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "duration_ms",
      "value": 5015545.333333333,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "total_requests_per_s",
      "value": 3304.3333333333335,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "percentile_75",
      "value": 20660.333333333332,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "total_requests_per_s",
      "value": 4609,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "minimum_latency",
      "value": 1758.6666666666667,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "average_latency",
      "value": 2155,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "minimum_latency",
      "value": -3.0744573456182574e+18,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "request_timeouts",
      "value": 0,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "http_errors",
      "value": 0,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "socket_write_errors",
      "value": 0,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "percentile_90",
      "value": 20786.666666666668,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "maximum_latency",
      "value": 330924.6666666667,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "duration_ms",
      "value": 5015183,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "socket_read_errors",
      "value": 0,
      "framework_id": 2
    },
    {
      "level": 512,
      "label": "standard_deviation",
      "value": 16095.333333333334,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "percentile_50",
      "value": 2129,
      "framework_id": 2
    },
    {
      "level": 64,
      "label": "request_timeouts",
      "value": 0,
      "framework_id": 2
    },
    {
      "level": 256,
      "label": "http_errors",
      "value": 0,
      "framework_id": 2
    }
  ]
```