### PR TITLE
update to use new passthrough param instead of pathParameters

### DIFF
--- a/javascript/spliffy/package.json
+++ b/javascript/spliffy/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
   "dependencies": {
-    "@srfnstack/spliffy": "~1.1.5"
+    "@srfnstack/spliffy": "~1.2.1"
   }
 }

--- a/javascript/spliffy/www/user/$id.rt.js
+++ b/javascript/spliffy/www/user/$id.rt.js
@@ -1,3 +1,3 @@
 export default {
-  GET: ({ url }) => url.pathParameters.id,
+  GET: ({ url }) => url.param('id'),
 };


### PR DESCRIPTION
update spliffy to 1.2.1 

should fix failures seen on (not sure how to run the tests) https://github.com/the-benchmarker/web-frameworks/pull/7182 