### PR TITLE
[Javascript] Clean-up clustering mode

### DIFF
--- a/.tasks/ci.rake
+++ b/.tasks/ci.rake
@@ -8,7 +8,7 @@ namespace :ci do
     files = Dir.glob('*/*/config.yaml') if files.include?('data.json')
 
     files += files
-             .find_all { |path| path.end_with?('Dockerfile') }
+             .find_all { |path| path.end_with?('Dockerfile') || (path.split('/').size == 2 && path.end_with?('config.yaml')) }
              .map { |path| path.split(File::SEPARATOR).shift }
              .flat_map { |language| Dir.glob(File.join(language, '*', 'config.yaml')) }
 

--- a/javascript/bunicorn/app.ts
+++ b/javascript/bunicorn/app.ts
@@ -8,4 +8,8 @@ app.addRoutes([
   rb.post("/user", (ctx) => ctx.ok()),
 ]);
 
-app.serve({ port: 3000 });
+Bun.serve({
+  fetch: app.handleRequest,
+  reusePort: true,
+  port: 3000
+})

--- a/javascript/config.yaml
+++ b/javascript/config.yaml
@@ -6,8 +6,9 @@ language:
       environment:
         NODE_ENV: production
       bootstrap:
+        - npm --location=global install pm2
         - npm install
-      command: node app.js
+      command: pm2-runtime start app.js -i $(nproc)
     turbo:
       environment:
         NODE_ENV: production
@@ -33,7 +34,7 @@ language:
     bun:
       bootstrap:
         - bun install
-      command: bun run app.ts
+      command: bun run cluster.ts
     happyx:
       bootstrap:
         - npm install

--- a/javascript/config.yaml
+++ b/javascript/config.yaml
@@ -6,9 +6,8 @@ language:
       environment:
         NODE_ENV: production
       bootstrap:
-        - npm --location=global install pm2
         - npm install
-      command: pm2-runtime start app.js -i $(nproc)
+      command: node app.js
     turbo:
       environment:
         NODE_ENV: production

--- a/javascript/config.yaml
+++ b/javascript/config.yaml
@@ -26,10 +26,8 @@ language:
         - npm install
       command: pm2-runtime start app.js -i $(nproc)
     deno:
-      deps:
-        - npm
       bootstrap:
-        - npm -g install pm2
+        - deno run -Ar https://deno.land/x/pup/pup.ts setup
       command: nohup pm2-runtime start "deno run --allow-net --allow-read=. app.ts" -i max
     bun:
       bootstrap:


### PR DESCRIPTION
This `PR` remove `pm2` usage.

To be fair with `deno`, `node` and `bun`, maybe we should remove `pm2` clustering.

What do you think  @pi0 @qin-guan @dalisoft @jkyberneees @schamberg97 @kartikk221 @mcollina ?

Regards,