### PR TITLE
Disable logging for Marten

### DIFF
--- a/crystal/marten/config/settings/base.cr
+++ b/crystal/marten/config/settings/base.cr
@@ -4,4 +4,5 @@ Marten.configure do |config|
   config.port = ENV["PORT"]? ? ENV["PORT"].to_i : 3000
   config.port_reuse = true
   config.allowed_hosts = ["*"]
+  config.log_level = Log::Severity::None
 end


### PR DESCRIPTION
# Description

This pull request simply disables logging for the Marten server, as I suspect this is dragging results down a bit. I am seeing that most frameworks benchmarked in this repository use a similar strategy, so it also makes sense to follow a similar approach for Marten.