### PR TITLE
Correct Debian version for Elixir frameworks

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -1,4 +1,13 @@
-FROM elixir:1.16 AS build
+ARG ELIXIR_VERSION=1.16.1
+ARG ERLANG_VERSION=26.2.2
+ARG DEBIAN_VERSION=bullseye-20240130
+
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${ERLANG_VERSION}-debian-${DEBIAN_VERSION}"
+ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
+
+# ===============================================================================================
+
+FROM ${BUILDER_IMAGE} AS build
 
 # Update system deps
 RUN apt-get -qq update
@@ -30,7 +39,7 @@ RUN mix release --path release
 
 # ===============================================================================================
 
-FROM debian:bullseye AS app
+FROM ${RUNNER_IMAGE} AS app
 
 # Update system deps
 RUN apt-get -qq update && apt-get -qy install --no-install-recommends openssl

--- a/elixir/cowboy/config.yaml
+++ b/elixir/cowboy/config.yaml
@@ -1,3 +1,3 @@
 framework:
-  website: ninenines.eu/docs/en/cowboy/2.10/guide/
-  version: "2.10"
+  website: ninenines.eu/docs/en/cowboy/2.11/guide/
+  version: "2.11"

--- a/elixir/cowboy/mix.exs
+++ b/elixir/cowboy/mix.exs
@@ -7,7 +7,7 @@ defmodule Server.MixProject do
       version: "0.1.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
-      deps: [{:cowboy, "~> 2.10.0"}],
+      deps: [{:cowboy, "~> 2.11.0"}],
       releases: [server: [include_executables_for: [:unix]]]
     ]
   end

--- a/elixir/cowboy_stream/config.yaml
+++ b/elixir/cowboy_stream/config.yaml
@@ -1,3 +1,3 @@
 framework:
-  website: ninenines.eu/docs/en/cowboy/2.10/guide/streams/
-  version: "2.10"
+  website: ninenines.eu/docs/en/cowboy/2.11/guide/streams/
+  version: "2.11"

--- a/elixir/cowboy_stream/mix.exs
+++ b/elixir/cowboy_stream/mix.exs
@@ -7,7 +7,7 @@ defmodule Server.MixProject do
       version: "0.1.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
-      deps: [{:cowboy, "~> 2.10.0"}],
+      deps: [{:cowboy, "~> 2.11.0"}],
       releases: [server: [include_executables_for: [:unix]]]
     ]
   end

--- a/elixir/phoenix_bandit/mix.exs
+++ b/elixir/phoenix_bandit/mix.exs
@@ -16,8 +16,8 @@ defmodule Server.MixProject do
 
   defp deps do
     [
-      {:phoenix, "~> 1.7.3"},
-      {:bandit, "~> 1.0-pre"},
+      {:phoenix, "~> 1.7.11"},
+      {:bandit, "~> 1.2.3"},
       {:jason, "~> 1.4"}
     ]
   end

--- a/elixir/phoenix_cowboy/mix.exs
+++ b/elixir/phoenix_cowboy/mix.exs
@@ -16,9 +16,9 @@ defmodule Server.MixProject do
 
   defp deps do
     [
-      {:phoenix, "~> 1.7.3"},
+      {:phoenix, "~> 1.7.11"},
       {:jason, "~> 1.4"},
-      {:plug_cowboy, "~> 2.6"}
+      {:plug_cowboy, "~> 2.7.0"}
     ]
   end
 end

--- a/elixir/plug_bandit/mix.exs
+++ b/elixir/plug_bandit/mix.exs
@@ -9,8 +9,8 @@ defmodule Server.MixProject do
       start_permanent: Mix.env() == :prod,
       releases: [server: [include_executables_for: [:unix]]],
       deps: [
-        {:plug, "~> 1.15.0"},
-        {:bandit, "~> 1.0-pre"}
+        {:plug, "~> 1.15.3"},
+        {:bandit, "~> 1.2.3"}
       ]
     ]
   end

--- a/elixir/plug_cowboy/mix.exs
+++ b/elixir/plug_cowboy/mix.exs
@@ -16,8 +16,8 @@ defmodule Server.MixProject do
 
   defp deps do
     [
-      {:plug, "~> 1.15.0"},
-      {:plug_cowboy, "~> 2.6"}
+      {:plug, "~> 1.15.3"},
+      {:plug_cowboy, "~> 2.7.0"}
     ]
   end
 end


### PR DESCRIPTION
The issue for all Elixir frameworks mentioned here https://github.com/the-benchmarker/web-frameworks/pull/7253 is probably due to mismatched versions of Debian for image `elixir:1.16` and `debian:bullseye` between build and runner images. I have fixed it by pinning the same version for the build and the runner image.

I have also updated all the packages.