### PR TITLE
Update to Hanami 2.1.0

### DIFF
--- a/ruby/hanami/Gemfile
+++ b/ruby/hanami/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'hanami', '~> 2.0.0'
-gem 'hanami-router', '~> 2.0.0'
+gem 'hanami', '~> 2.1.0'
+gem 'hanami-router', '~> 2.1.0'


### PR DESCRIPTION
In #7260 and #7261, Renovate attempted to update the hanami and hanami-router gems to 2.1.0 _separately._

However, Hanami 2.1 requires these gems to be updated _together._

In this PR, I'm updating both gems, which should see the Hanami tests continue to pass.

Thanks for giving me a heads up, @waghanza!