### PR TITLE
disable unused django apps and middlewares

### DIFF
--- a/python/django/app/views.py
+++ b/python/django/app/views.py
@@ -1,5 +1,4 @@
 from django.http import HttpResponse
-from django.views.decorators.csrf import csrf_exempt
 
 
 def index(request):
@@ -10,6 +9,5 @@ def get_user(request, id):
     return HttpResponse(id)
 
 
-@csrf_exempt
 def create_user(request):
     return HttpResponse(status=200)

--- a/python/django/settings.py
+++ b/python/django/settings.py
@@ -16,24 +16,9 @@ ALLOWED_HOSTS += ["172.17.%s.%s" % (i, j) for i in range(256) for j in range(256
 
 # Application definition
 
-INSTALLED_APPS = [
-    "django.contrib.admin",
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
-    "django.contrib.sessions",
-    "django.contrib.messages",
-    "django.contrib.staticfiles",
-]
+INSTALLED_APPS = []
 
-MIDDLEWARE = [
-    "django.middleware.security.SecurityMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
-    "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",
-    "django.middleware.clickjacking.XFrameOptionsMiddleware",
-]
+MIDDLEWARE = []
 
 ROOT_URLCONF = "app.urls"
 


### PR DESCRIPTION
Django has a lot of stuff enabled by default which worsens performance significantly. It would be much more fair to disable them IMHO.