### PR TITLE
Add PHP 8.3 support

### DIFF
--- a/php/antidot/config.yaml
+++ b/php/antidot/config.yaml
@@ -1,8 +1,9 @@
 language:
-  version: 8.2
   engines:
     reactphp:
       command: bin/console serve
+      environment:
+        COMPOSER_ALLOW_SUPERUSER: 1
 
 framework:
   website: antidotfw.io
@@ -17,3 +18,6 @@ framework:
 
   engines:
     - reactphp
+
+  bootstrap:
+    - mkdir var/cache -p


### PR DESCRIPTION
Hi waghanza,

I just updated Antidot framework dependencies to work with PHP 8.3. Sorry for the delay, but I hadn't realized it wasn't working. 

Thank you very much for your excellent work. 