### PR TITLE
[D] Added Hunt and updated versions for serverino and vibe worker pool

### DIFF
--- a/d/hunt/.gitignore
+++ b/d/hunt/.gitignore
@@ -1,0 +1,3 @@
+.dub/
+server
+dub.selections.json

--- a/d/hunt/config.yaml
+++ b/d/hunt/config.yaml
@@ -1,0 +1,3 @@
+framework:
+  github: huntlabs/hunt-http
+  version: 0.8

--- a/d/hunt/dub.json
+++ b/d/hunt/dub.json
@@ -1,0 +1,8 @@
+{
+    "name": "server",
+    "dependencies": {
+      "hunt-http": "~>0.8.2"
+    },
+    "dflags-ldc": ["-mcpu=native"],
+    "license": "MIT"
+  }

--- a/d/hunt/source/app.d
+++ b/d/hunt/source/app.d
@@ -1,0 +1,28 @@
+import hunt.http;
+
+void main()
+{
+    HttpServerOptions serverOptions = new HttpServerOptions();
+	serverOptions.setSecureConnectionEnabled(false);
+	serverOptions.setFlowControlStrategy("simple");
+	serverOptions.setHost("0.0.0.0");
+	serverOptions.setPort(3000);
+
+    auto server = HttpServer.builder(serverOptions)
+        .addRoute("/", (RoutingContext context) {
+            context.responseHeader(HttpHeader.CONTENT_TYPE, MimeType.TEXT_PLAIN_VALUE);
+            context.end();
+        })
+        .onPost("/user", (RoutingContext context) {
+            context.responseHeader(HttpHeader.CONTENT_TYPE, MimeType.TEXT_PLAIN_VALUE);
+            context.end();
+        })
+        .onGet("/user/:id", (RoutingContext ctx) {
+            string id = ctx.getRouterParameter("id");
+            ctx.responseHeader(HttpHeader.CONTENT_TYPE, MimeType.TEXT_PLAIN_VALUE);
+            ctx.end(id);
+        })
+        .build();
+
+    server.start();
+}

--- a/d/serverino/dub.json
+++ b/d/serverino/dub.json
@@ -1,7 +1,7 @@
 {
   "name": "server",
   "dependencies": {
-    "serverino": "~>0.7.0"
+    "serverino": "~>0.7.9"
   },
   "dflags-ldc": ["-mcpu=native"],
   "subConfigurations": { "serverino": "disable_websockets" },

--- a/d/serverino/source/app.d
+++ b/d/serverino/source/app.d
@@ -14,7 +14,7 @@ mixin ServerinoMain;
         .setHttpTimeout(10.seconds)
         .enableKeepAlive(180.seconds)
         .addListener("0.0.0.0", 3000)
-        .setWorkers(8);
+        .setWorkers(50);
 }
 
 @safe

--- a/d/vibed/dub.json
+++ b/d/vibed/dub.json
@@ -1,8 +1,8 @@
 {
   "name": "server",
   "dependencies": {
-    "vibe-d:http": "~>0.10.0",
-    "vibe-d:tls": "*"
+      "vibe-http": "~>1.1.0",
+      "vibe-stream:tls": "~>1.1.0"
   },
   "versions": [
     "VibeManualMemoryManagement",
@@ -11,7 +11,7 @@
   ],
   "dflags-ldc": ["-mcpu=native"],
   "subConfigurations": {
-    "vibe-d:tls": "notls"
+    "vibe-stream:tls": "notls"
   },
   "license": "MIT"
 }

--- a/d/vibed/source/app.d
+++ b/d/vibed/source/app.d
@@ -17,7 +17,7 @@ void handleRequest(scope HTTPServerRequest req, scope HTTPServerResponse res)
 
 void main()
 {
-    setupWorkerThreads(totalCPUs);
+    setupWorkerThreads(50);
     runWorkerTask(&runServer);
 	runApplication();
 }


### PR DESCRIPTION
This PR is adding new framework for D - Hunt http server.
I've also updated the worker pool size for serverino and vibe. Because larger pool sizes work better for me locally (but I've tested on macOS and M1). Hopefully it will improve the performance in Linux/Docker as well.