### PR TITLE
[Crystal] Update Marten version to 0.5

### DIFF
--- a/crystal/marten/config.yaml
+++ b/crystal/marten/config.yaml
@@ -1,7 +1,7 @@
 framework:
   website: martenframework.com
   github: martenframework/marten
-  version: 0.4
+  version: 0.5
 
 environment:
   MARTEN_ENV: production

--- a/crystal/marten/shard.yml
+++ b/crystal/marten/shard.yml
@@ -13,4 +13,4 @@ targets:
 dependencies:
   marten:
     github: martenframework/marten
-    version: ~> 0.4.0
+    version: ~> 0.5.0


### PR DESCRIPTION
The [0.5 major version of Marten](https://martenframework.com/docs/the-marten-project/release-notes/0.5) was released yesterday. This pull request ensures that the Marten project used for this benchmark is set to use this latest major release.