### PR TITLE
Upgrade `athena` to `0.19`

### DIFF
--- a/crystal/athena/config.yaml
+++ b/crystal/athena/config.yaml
@@ -1,6 +1,6 @@
 framework:
   github: athena-framework/athena
-  version: 0.17
+  version: 0.19
 
 environment:
   ATHENA_ENV: production

--- a/crystal/athena/shard.yml
+++ b/crystal/athena/shard.yml
@@ -11,6 +11,6 @@ targets:
 dependencies:
   athena:
     github: athena-framework/framework
-    version: ~> 0.17.0
+    version: ~> 0.19.0
 
 license: MIT


### PR DESCRIPTION
Should resolve the failures as part of https://github.com/the-benchmarker/web-frameworks/pull/7615.