### PR TITLE
chore(rails): update the number of puma threads to 3

### DIFF
--- a/ruby/rails-api/config/application.rb
+++ b/ruby/rails-api/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module Benchmark
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.1
+    config.load_defaults 7.2
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.

--- a/ruby/rails-api/config/puma.rb
+++ b/ruby/rails-api/config/puma.rb
@@ -5,9 +5,9 @@
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
-# the maximum value specified for Puma. Default is set to 5 threads for minimum
+# the maximum value specified for Puma. Default is set to 3 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
-max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 3)
 min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count
 

--- a/ruby/rails/config/application.rb
+++ b/ruby/rails/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module Benchmark
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.1
+    config.load_defaults 7.2
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.

--- a/ruby/rails/config/puma.rb
+++ b/ruby/rails/config/puma.rb
@@ -5,9 +5,9 @@
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
-# the maximum value specified for Puma. Default is set to 5 threads for minimum
+# the maximum value specified for Puma. Default is set to 3 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
-max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 3)
 min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count
 


### PR DESCRIPTION
The default value of puma threads has been [updated](https://edgeguides.rubyonrails.org/7_2_release_notes.html#set-a-new-default-for-the-puma-thread-count) in rails 7.2, now there are 3 of them.