### PR TITLE
Enable YJIT for Ruby

### DIFF
--- a/ruby/config.yaml
+++ b/ruby/config.yaml
@@ -33,6 +33,7 @@ framework:
     - config.ru
 
   environment:
+    RUBY_YJIT_ENABLE: 1
     RACK_ENV: production
     BUNDLE_WITHOUT: "development,test"
     SECRET_KEY_BASE: Awe$ome_Secret.

--- a/ruby/rails-api/config.yaml
+++ b/ruby/rails-api/config.yaml
@@ -8,3 +8,5 @@ framework:
   environment:
     RAILS_ENV: production
     RAILS_LOG_LEVEL: fatal
+    # Rails enables YJIT after the app has initialized 
+    RUBY_YJIT_ENABLE: 0

--- a/ruby/rails/config.yaml
+++ b/ruby/rails/config.yaml
@@ -8,3 +8,5 @@ framework:
   environment:
     RAILS_ENV: production
     RAILS_LOG_LEVEL: fatal
+    # Rails enables YJIT after the app has initialized 
+    RUBY_YJIT_ENABLE: 0


### PR DESCRIPTION
Rails 7.2 enables YJIT itself after initialization.
This makes sure code that only runs on initializing is not jitted.
So for Rails we set RUBY_YJIT_ENABLE to falsey.