### PR TITLE
Refactor controller to use functional routing

### DIFF
--- a/java/spring-webflux/src/main/java/framework/benchmark/controller/BenchmarkController.java
+++ b/java/spring-webflux/src/main/java/framework/benchmark/controller/BenchmarkController.java
@@ -1,4 +1,4 @@
-package framework.benchmark.router;
+package framework.benchmark.controller;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;

--- a/java/spring-webflux/src/main/java/framework/benchmark/controller/BenchmarkController.java
+++ b/java/spring-webflux/src/main/java/framework/benchmark/controller/BenchmarkController.java
@@ -13,7 +13,7 @@ import static org.springframework.web.reactive.function.server.RequestPredicates
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
 @Component
-public class BenchmarkRouter {
+public class BenchmarkController {
 
     private static final Mono<ServerResponse> EMPTY_RESPONSE = ServerResponse.ok().build();
 

--- a/java/spring-webflux/src/main/java/framework/benchmark/controller/BenchmarkController.java
+++ b/java/spring-webflux/src/main/java/framework/benchmark/controller/BenchmarkController.java
@@ -15,28 +15,14 @@ import static org.springframework.web.reactive.function.server.RouterFunctions.r
 @Component
 public class BenchmarkRouter {
 
-    private static final Mono<ServerResponse> EMPTY_RESPONSE = ServerResponse.ok()
-            .contentType(MediaType.TEXT_PLAIN)
-            .body(Mono.empty(), String.class);
+    private static final Mono<ServerResponse> EMPTY_RESPONSE = ServerResponse.ok().build();
 
     @Bean
     public RouterFunction<ServerResponse> routes() {
-        return route(GET("/"), this::root)
-                .andRoute(GET("/user/{id}"), this::userId)
-                .andRoute(POST("/user"), this::user);
-    }
-
-    // Reuse empty response to avoid constant re-creation
-    public Mono<ServerResponse> root(ServerRequest request) {
-        return EMPTY_RESPONSE;
-    }
-
-    public Mono<ServerResponse> userId(ServerRequest request) {
-        // Directly parse the id from path variable without extra boxing/unboxing
-        return ServerResponse.ok().bodyValue(Integer.parseInt(request.pathVariable("id")));
-    }
-
-    public Mono<ServerResponse> user(ServerRequest request) {
-        return EMPTY_RESPONSE;
+        return route()
+                .GET("/", request -> EMPTY_RESPONSE)
+                .GET("/user/{id}", request -> ServerResponse.ok().bodyValue(request.pathVariable("id")))
+                .POST("/user", request -> EMPTY_RESPONSE)
+                .build();
     }
 }

--- a/java/spring-webflux/src/main/java/framework/benchmark/controller/BenchmarkController.java
+++ b/java/spring-webflux/src/main/java/framework/benchmark/controller/BenchmarkController.java
@@ -1,28 +1,42 @@
-package framework.benchmark.controller;
+package framework.benchmark.router;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
 
-@RestController
-public class BenchmarkController {
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
+import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 
-    private static final String EMPTY = "";
+@Component
+public class BenchmarkRouter {
 
-    @GetMapping("/")
-    public Mono<String> root() {
-        return Mono.just(EMPTY);
+    private static final Mono<ServerResponse> EMPTY_RESPONSE = ServerResponse.ok()
+            .contentType(MediaType.TEXT_PLAIN)
+            .body(Mono.empty(), String.class);
+
+    @Bean
+    public RouterFunction<ServerResponse> routes() {
+        return route(GET("/"), this::root)
+                .andRoute(GET("/user/{id}"), this::userId)
+                .andRoute(POST("/user"), this::user);
     }
 
-    @GetMapping("/user/{id}")
-    public Mono<Integer> userId(@PathVariable Integer id) {
-        return Mono.just(id);
+    // Reuse empty response to avoid constant re-creation
+    public Mono<ServerResponse> root(ServerRequest request) {
+        return EMPTY_RESPONSE;
     }
 
-    @PostMapping("/user")
-    public Mono<String> user() {
-        return Mono.just(EMPTY);
+    public Mono<ServerResponse> userId(ServerRequest request) {
+        // Directly parse the id from path variable without extra boxing/unboxing
+        return ServerResponse.ok().bodyValue(Integer.parseInt(request.pathVariable("id")));
+    }
+
+    public Mono<ServerResponse> user(ServerRequest request) {
+        return EMPTY_RESPONSE;
     }
 }


### PR DESCRIPTION
Replaces the annotation-based controller with a functional routing approach. Introduces a `RouterFunction` bean to handle HTTP requests, eliminates redundant response creation, and improves efficiency by directly parsing path variables.