### PR TITLE
fix(javascript/fastify): fixed body parser.

### DIFF
--- a/javascript/fastify-bun/app.ts
+++ b/javascript/fastify-bun/app.ts
@@ -1,5 +1,6 @@
 import fastify from 'fastify';
 const app = fastify();
+app.register(await import('@fastify/formbody'));
 
 app.get('/', function (request, reply) {
   reply.send();

--- a/javascript/fastify-bun/package.json
+++ b/javascript/fastify-bun/package.json
@@ -1,6 +1,7 @@
 {
   "type": "module",
   "dependencies": {
+    "@fastify/formbody": "^8.0.1",
     "fastify": "~5.1.0"
   }
 }

--- a/javascript/fastify/app.js
+++ b/javascript/fastify/app.js
@@ -1,5 +1,6 @@
 const fastify = require('fastify');
 const app = fastify();
+app.register(require('@fastify/formbody'));
 
 app.get('/', function (request, reply) {
   reply.send();

--- a/javascript/fastify/package.json
+++ b/javascript/fastify/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@fastify/formbody": "^8.0.1",
     "fastify": "~5.1.0"
   }
 }


### PR DESCRIPTION
As you can see from the benchmarks, fastify throws errors:

![image](https://github.com/user-attachments/assets/ae08b524-2b44-4888-ba7b-de67a58b6b8b)

This is because POST requests are not actually parsed because there is no parser for this type:

https://github.com/the-benchmarker/web-frameworks/blob/19027d3c8e8a580b26e5c45c3cf2486313a9e22b/pipeline_post.lua#L3
