### PR TITLE
[Scala]: Adding Apache Pekko.

### DIFF
--- a/scala/pekkohttp/.gitignore
+++ b/scala/pekkohttp/.gitignore
@@ -1,0 +1,3 @@
+project/project
+project/target
+target/

--- a/scala/pekkohttp/build.sbt
+++ b/scala/pekkohttp/build.sbt
@@ -1,0 +1,11 @@
+name := "server"
+scalaVersion := "3.5.2"
+
+val PekkoVersion = "1.1.2"
+val PekkoHttpVersion = "1.1.0"
+libraryDependencies ++= Seq(
+  "org.apache.pekko" %% "pekko-actor-typed" % PekkoVersion,
+  "org.apache.pekko" %% "pekko-stream" % PekkoVersion,
+  "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion
+)
+enablePlugins(JavaAppPackaging)

--- a/scala/pekkohttp/config.yaml
+++ b/scala/pekkohttp/config.yaml
@@ -1,0 +1,3 @@
+framework:
+  website: pekko.apache.org
+  version: 1.1.0

--- a/scala/pekkohttp/project/build.properties
+++ b/scala/pekkohttp/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.9

--- a/scala/pekkohttp/project/plugins.sbt
+++ b/scala/pekkohttp/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "latest.integration")

--- a/scala/pekkohttp/src/main/scala/Main.scala
+++ b/scala/pekkohttp/src/main/scala/Main.scala
@@ -1,0 +1,25 @@
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.http.scaladsl.Http
+import pekko.http.scaladsl.server.Directives._
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    implicit val system = ActorSystem("PekkoHttp")
+
+    val route =
+      pathSingleSlash {
+        complete("")
+      } ~
+        path("user") {
+          post {
+            complete("")
+          }
+        } ~
+        path("user" / Remaining) { id =>
+          complete(id)
+        }
+
+    Http().bindAndHandle(route, "0.0.0.0", 3000)
+  }
+}


### PR DESCRIPTION
Akka (backed by Lightbend, who recently changed name and is actually _itself_ now called [Akka](https://akka.io)) [changed its licence](https://akka.io/blog/why-we-are-changing-the-license-for-akka).
Quickly after that, an open source fork was born under the Apache foundation with the name [Pekko](https://pekko.apache.org/).

Pekko is essentially Akka 2.6. 