### PR TITLE
Add content-type parser to Fastify

### DIFF
--- a/javascript/fastify/app.js
+++ b/javascript/fastify/app.js
@@ -11,6 +11,11 @@ app.get('/user/:id', function (request, reply) {
   reply.send(request.params.id);
 });
 
+app.addContentTypeParser('application/x-www-form-urlencoded', function (req, body, done) {
+  // The incoming request in the benchmark is empty anyway
+  done();
+});
+
 app.post('/user', function (request, reply) {
   reply.send();
 });


### PR DESCRIPTION
The Fastify application is reporting errors (and lower benchmarks result) because it wasn't properly configured to accept the incoming Content-Type for the POST request.

Before:

```bash
➜  fastify git:(master) ✗ wrk -c 64 --script ../../pipeline_post.lua http://localhost:3000/user
Running 10s test @ http://localhost:3000/user
  2 threads and 64 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.11ms    1.61ms  74.32ms   99.70%
    Req/Sec    30.88k     1.72k   32.12k    98.02%
  620747 requests in 10.10s, 208.97MB read
  Non-2xx or 3xx responses: 620747
Requests/sec:  61459.98
Transfer/sec:     20.69MB
10100019,620747,61459,219123691,0,0,0,620747,0,316,74318,1109,1610,1015,1047,1093,2018,70820%
```

After this change, the errors are gone, and the req/s almost doubled:

```bash
➜  fastify git:(master) ✗ wrk -c 64 --script ../../pipeline_post.lua http://localhost:3000/user
Running 10s test @ http://localhost:3000/user
  2 threads and 64 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   582.88us    1.04ms  54.42ms   99.71%
    Req/Sec    59.21k     4.35k   64.44k    92.08%
  1189983 requests in 10.10s, 139.59MB read
Requests/sec: 117813.56
Transfer/sec:     13.82MB
10100561,1189983,117813,146367909,0,0,0,0,0,108,54423,582,1041,505,605,629,1007,51708%
```