### PR TITLE
Adding the protobuf PHP extension for php/roadrunner

### DIFF
--- a/php/config.yaml
+++ b/php/config.yaml
@@ -25,6 +25,8 @@ language:
         - sockets
       command: php public/index.php start
     road-runner:
+      extensions:
+        - protobuf
       files:
         - .rr.yaml
       bootstrap:


### PR DESCRIPTION
According to the instructions [https://docs.roadrunner.dev/docs/general/compatibility#upgrading-to-roadrunner-v2024.1.x](https://docs.roadrunner.dev/docs/general/compatibility#upgrading-to-roadrunner-v2024.1.x) for the latest versions of roadrunner, it is recommended to use the `protobuf` PHP extension.