### PR TITLE
🐦 Falco v5.x

### DIFF
--- a/fsharp/falco/Program.fs
+++ b/fsharp/falco/Program.fs
@@ -1,39 +1,22 @@
-module Program 
+module Program
 
 open Falco
-open Falco.HostBuilder
 open Falco.Routing
 open Microsoft.AspNetCore.Builder
-open Microsoft.AspNetCore.Hosting
-open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Logging
 
-let configureLogging (log : ILoggingBuilder) =
-    log.ClearProviders()
-    |> ignore
+[<EntryPoint>]
+let main args =
+    let bldr = WebApplication.CreateBuilder(args)
+    bldr.Logging.ClearProviders() |> ignore
 
-let configureServices (services : IServiceCollection) =
-    services.AddFalco() 
-    |> ignore
+    let wapp = bldr.Build()
 
-let configure (endpoints : HttpEndpoint list) (app : IApplicationBuilder) = 
-    app.UseFalco(endpoints)       
-    |> ignore 
-    
-let configureWebHost (endpoints : HttpEndpoint list) (webHost : IWebHostBuilder) =    
-    webHost        
-        .UseKestrel(fun k -> k.AddServerHeader <- false)
-        .ConfigureLogging(configureLogging)
-        .ConfigureServices(configureServices)
-        .Configure(configure endpoints)        
-
-let args = System.Environment.GetCommandLineArgs()
-
-webHost args {
-    configure configureWebHost
-    endpoints [
-        get  "/user/{id}" (Request.mapRoute (fun route -> route.Get "id" "") Response.ofPlainText)
-        post "/user"      (Response.ofEmpty)
-        get  "/"          (Response.ofEmpty)
-    ]
-}    
+    wapp.UseRouting()
+        .UseFalco([
+            mapGet  "/user/{id}" (fun r -> r.GetString "id") Response.ofPlainText
+            post "/user" Response.ofEmpty
+            get  "/" Response.ofEmpty
+        ])
+        .Run()
+    0

--- a/fsharp/falco/config.yaml
+++ b/fsharp/falco/config.yaml
@@ -1,3 +1,3 @@
 framework:
   website: www.falcoframework.com
-  version: 3.1
+  version: 5.0

--- a/fsharp/falco/web.fsproj
+++ b/fsharp/falco/web.fsproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.fs" />
-  </ItemGroup>  
+  </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.*" />
-    <PackageReference Include="Falco" Version="3.1.*" />
+    <PackageReference Include="Falco" Version="5.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates Falco F# from version 3.1 to 5.0 and the dotnet runtime from version 8.0 to 9.0.

NuGet references will resolve to latest stable release of major versions. See: https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#references-in-project-files-packagereference
