### PR TITLE
f# upgrade to net9.0

### DIFF
--- a/fsharp/Dockerfile
+++ b/fsharp/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS build
 
 WORKDIR /usr/src/app
 
@@ -10,7 +10,7 @@ RUN dotnet restore
 COPY . .
 RUN dotnet publish -c release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-bookworm-slim
 
 WORKDIR /usr/src/app
 

--- a/fsharp/config.yaml
+++ b/fsharp/config.yaml
@@ -1,5 +1,5 @@
 language:
-  version: 8.0
+  version: 9.0
 
   files:
     - "**/*.fs"

--- a/fsharp/falco/web.fsproj
+++ b/fsharp/falco/web.fsproj
@@ -6,6 +6,7 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="7.0.*" />
     <PackageReference Include="Falco" Version="5.*" />
   </ItemGroup>
 </Project>

--- a/fsharp/frank/web.fsproj
+++ b/fsharp/frank/web.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.fs" />

--- a/fsharp/giraffe-endpoints/web.fsproj
+++ b/fsharp/giraffe-endpoints/web.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>web</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/fsharp/giraffe/web.fsproj
+++ b/fsharp/giraffe/web.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>web</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/fsharp/saturn/web.fsproj
+++ b/fsharp/saturn/web.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/fsharp/suave/Program.fs
+++ b/fsharp/suave/Program.fs
@@ -11,14 +11,14 @@ let app: WebPart =
                         pathScan "/user/%s" (fun s -> Successful.OK s) ]
           POST >=> path "/user" >=> Successful.OK "" ]
 
-type NoopLogger() = 
-    interface Logger with 
+type NoopLogger() =
+    interface Logger with
         member this.name : string[] = [|"null-logger"|]
         member this.logWithAck (logLevel : LogLevel) (logLevelWithMessage : (LogLevel -> Message)): Async<unit> =
             async {
                 ()
             }
-        member this.log (loglevel : LogLevel) (logLevelWithMessage : (LogLevel -> Message)): unit = 
+        member this.log (loglevel : LogLevel) (logLevelWithMessage : (LogLevel -> Message)): unit =
             ()
 
 let config =

--- a/fsharp/suave/web.fsproj
+++ b/fsharp/suave/web.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/fsharp/websharper/web.fsproj
+++ b/fsharp/websharper/web.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <WebSharperProject>Website</WebSharperProject>
     <WebProjectOutputDir>$(MSBuildThisFileDirectory)/wwwroot</WebProjectOutputDir>
   </PropertyGroup>


### PR DESCRIPTION
I apologize, I didn't think to look at the other F# projects. I had just assumed they were already using net9.0.

This upgrade brings the full gamut up to the latest SDK, which should allow all the actions to pass. It looks like the test check last time died during the build phase because an older SDK was present. See: https://github.com/the-benchmarker/web-frameworks/actions/runs/13100015194/job/36547106181?pr=8203