### PR TITLE
fix(hono-deno): use npm library

### DIFF
--- a/javascript/hono-deno/app.ts
+++ b/javascript/hono-deno/app.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'https://deno.land/x/hono/mod.ts'
+import { Hono } from 'hono'
 
 const app = new Hono();
 


### PR DESCRIPTION
Hono is no longer published on `deno.land/x`. Change to refer to the package on npm to apply the latest version.
https://github.com/honojs/hono/blob/main/docs/MIGRATION.md