### PR TITLE
feat(frank): update to Frank 6.3

### DIFF
--- a/fsharp/frank/config.yaml
+++ b/fsharp/frank/config.yaml
@@ -1,3 +1,3 @@
 framework:
   github: frank-fs/frank
-  version: 6.2
+  version: 6.3

--- a/fsharp/frank/web.fsproj
+++ b/fsharp/frank/web.fsproj
@@ -6,7 +6,6 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.*" />
-    <PackageReference Include="Frank" Version="6.2.*" />
+    <PackageReference Include="Frank" Version="6.3.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I just recently updated Frank to have better support for net8.0 and net9.0. I've updated the sample to use the newer version 6.3.