### PR TITLE
update(haskell/servant): Update to servant-0.20

### DIFF
--- a/haskell/servant/config.yaml
+++ b/haskell/servant/config.yaml
@@ -1,3 +1,3 @@
 framework:
   website: docs.servant.dev
-  version: 0.18
+  version: 0.20

--- a/haskell/servant/server.cabal
+++ b/haskell/servant/server.cabal
@@ -10,10 +10,11 @@ library
   hs-source-dirs:      src
   exposed-modules:     Lib
   build-depends:       base >= 4.7 && < 5
-                     , servant >= 0.18 && < 0.19
+                     , servant >= 0.20 && < 0.21
                      , servant-server
                      , wai
                      , warp
+                     , text
   default-language:    Haskell2010
 
 executable server

--- a/haskell/servant/src/Lib.hs
+++ b/haskell/servant/src/Lib.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 module Lib
   ( startApp,
@@ -11,26 +12,35 @@ where
 import Network.Wai
 import Network.Wai.Handler.Warp
 import Servant
+import Servant.API.Generic
+import Servant.Server.Generic
+import Data.Text (Text)
 
-type API =
-  Get '[PlainText] String
-    :<|> "user" :> Capture "id" String :> Get '[PlainText] String
-    :<|> "user" :> Post '[PlainText] String
+data API routes = API
+  { _get  :: routes :-                                Get  '[PlainText] Text
+  , _echo :: routes :- "user" :> Capture "id" Text :> Get  '[PlainText] Text
+  , _post :: routes :- "user" :>                      Post '[PlainText] Text
+  }
+  deriving (Generic)
 
 startApp :: IO ()
 startApp = run 3000 app
 
 app :: Application
-app = serve api server
+app = genericServe server
 
-api :: Proxy API
-api = Proxy
+api :: Proxy (ToServantApi API)
+api = genericApi (Proxy :: Proxy API)
 
-server :: Server API
-server = return notMuch :<|> echoId :<|> return notMuch
+server :: API AsServer
+server = API
+  { _get  = notMuch
+  , _echo = echoId
+  , _post = notMuch
+  }
 
-notMuch :: String
-notMuch = ""
+notMuch :: Handler Text
+notMuch = pure ""
 
-echoId :: String -> Handler String
+echoId :: Text -> Handler Text
 echoId = pure


### PR DESCRIPTION
Makes three changes to the Haskell Servant entry:

 * Uses servant-0.20, released in August last year.
 * Use the `Text` type, to avoid unnecessary conversion via Haskell's very inefficient `String` type. Hopefully this will improve performance (there's no good reason for the Servant entry to be any slower than the scotty one).
 * Defines the API using the relatively new `Servant.API.Generic`, which is a little less cryptic than the incantation traditionally used in API definitions. I haven't run the benchmarks, only tested that it compiles with the version of GHC.