### PR TITLE
Add Julia HTTP.jl

### DIFF
--- a/julia/http/Project.toml
+++ b/julia/http/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+
+[compat]
+HTTP = "1"

--- a/julia/http/Project.toml
+++ b/julia/http/Project.toml
@@ -2,4 +2,4 @@
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 
 [compat]
-HTTP = "1"
+HTTP = "1.10"

--- a/julia/http/config.yaml
+++ b/julia/http/config.yaml
@@ -1,3 +1,3 @@
 framework:
   github: JuliaWeb/HTTP.jl
-  version: 1
+  version: 1.10

--- a/julia/http/config.yaml
+++ b/julia/http/config.yaml
@@ -1,0 +1,3 @@
+framework:
+  github: JuliaWeb/HTTP.jl
+  version: 1

--- a/julia/http/deps.jl
+++ b/julia/http/deps.jl
@@ -1,0 +1,6 @@
+using Pkg
+
+Pkg.activate(pwd())
+Pkg.Registry.add(RegistrySpec(url = "https://github.com/JuliaRegistries/General"))
+Pkg.update()
+Pkg.resolve()

--- a/julia/http/server.jl
+++ b/julia/http/server.jl
@@ -1,0 +1,10 @@
+using Pkg
+Pkg.activate(pwd())
+
+using HTTP
+
+R = HTTP.Router()
+HTTP.register!(R, "GET", "/", (req::HTTP.Request) -> HTTP.Response(200, ""))
+HTTP.register!(R, "GET", "/user/{id}", (req::HTTP.Request) -> HTTP.Response(200, HTTP.getparams(req)["id"]))
+HTTP.register!(R, "POST", "/user", (req::HTTP.Request) -> HTTP.Response(200, ""))
+HTTP.serve(R, "0.0.0.0", 3000)


### PR DESCRIPTION
Adds [JuliaWeb/HTTP.jl](https://github.com/JuliaWeb/HTTP.jl), based on https://github.com/the-benchmarker/web-frameworks/pull/8482

This will grab the latest HTTP.jl with major version 1 and minor version greater than 10, though note work is under way for version 2 at https://github.com/JuliaWeb/HTTP.jl/pull/1213. When that is merged the compat will need to be bumped.


Does the benchmark do any warmup requests? This is important to get good results in Julia since it is doing lazy compilation on the first requests.