### PR TITLE
Fix emmett implementation

### DIFF
--- a/python/emmett/config.yaml
+++ b/python/emmett/config.yaml
@@ -1,20 +1,12 @@
 framework:
   website: emmett.sh
-  version: 2.6
+  version: 2.7
 
   engines:
     - emmett
-    - gunicorn
-
-  build_deps:
-    - libffi-dev
-    - libssl-dev
 
 language:
-  version: 3.12
+  version: 3.13
   engines:
-    gunicorn:
-      environment:
-        WORKER_CLASS: emmett.asgi.workers.EmmettWorker
     emmett:
-      command: emmett serve --host 0.0.0.0 --port 3000 --workers $(nproc)
+      command: emmett serve --host 0.0.0.0 --port 3000 --http 1 --workers $(nproc)

--- a/python/emmett/config.yaml
+++ b/python/emmett/config.yaml
@@ -8,4 +8,4 @@ framework:
 language:
   engines:
     emmett:
-      command: emmett serve --host 0.0.0.0 --port 3000 --http 1 --workers $(nproc)
+      command: emmett serve --host 0.0.0.0 --port 3000 --workers $(nproc)

--- a/python/emmett/config.yaml
+++ b/python/emmett/config.yaml
@@ -6,7 +6,6 @@ framework:
     - emmett
 
 language:
-  version: 3.13
   engines:
     emmett:
       command: emmett serve --host 0.0.0.0 --port 3000 --http 1 --workers $(nproc)

--- a/python/emmett/pyproject.toml
+++ b/python/emmett/pyproject.toml
@@ -7,5 +7,4 @@ requires = ["flit_core"]
 name='server'
 version = '1.0.0'
 description = "Simple benchmark implementation"
-dependencies = ["emmett>=2.7,<2.8"]
-
+dependencies = ["emmett[uvloop]>=2.7,<2.8"]


### PR DESCRIPTION
Specifically:
- use `uvloop`
- bump Python to 3.13
- remove legacy config