### PR TITLE
Guile fibers/web: Simplify code: only do what’s needed.

### DIFF
--- a/guile/fibers/server.scm
+++ b/guile/fibers/server.scm
@@ -5,18 +5,17 @@
   (define method (request-method request))
   (define path (uri-path (request-uri request)))
   (define userpath "/user")
+  (define userpath? (string-prefix? userpath path))
   (values
    (build-response
     #:headers `((content-type . (text/plain)))
     #:code 200)
    (cond
     ((and (equal? method 'POST)
-          (string-prefix-ci? userpath path))
+          userpath?)
      "")
-    ((string-prefix-ci? userpath path)
+    (userpath?
      (string-drop path (1+ (string-length userpath))))
-    ((equal? "/" path)
-     "")
     (else ""))))
 
 (define (main args)

--- a/guile/web/server.scm
+++ b/guile/web/server.scm
@@ -5,18 +5,17 @@
   (define method (request-method request))
   (define path (uri-path (request-uri request)))
   (define userpath "/user")
+  (define userpath? (string-prefix? userpath path))
   (values
    (build-response
     #:headers `((content-type . (text/plain)))
     #:code 200)
    (cond
     ((and (equal? method 'POST)
-          (string-prefix-ci? userpath path))
+          userpath?)
      "")
-    ((string-prefix-ci? userpath path)
+    (userpath?
      (string-drop path (1+ (string-length userpath))))
-    ((equal? "/" path)
-     "")
     (else ""))))
 
 (define (main args)


### PR DESCRIPTION
Case insensitive path comparison isn’t actually needed (and should often explicitly not be done), so I removed it.