### PR TITLE
Switch http4s backed to ember (default)

### DIFF
--- a/scala/http4s/build.sbt
+++ b/scala/http4s/build.sbt
@@ -6,7 +6,7 @@ scalaVersion := "3.7.2"
 lazy val root = (project in file("."))
   .settings(
     libraryDependencies ++= Seq(
-      "org.http4s" %% "http4s-blaze-server" % Http4sVersionRange,
+      "org.http4s" %% "http4s-ember-server" % Http4sVersionRange,
       "org.http4s" %% "http4s-dsl" % Http4sVersionRange
     )
   )

--- a/scala/http4s/src/main/scala/the/benchmarker/http4s/Main.scala
+++ b/scala/http4s/src/main/scala/the/benchmarker/http4s/Main.scala
@@ -1,12 +1,14 @@
 package the.benchmarker.http4s
 
-import cats.effect._
-import org.http4s.dsl.io._
-import org.http4s.implicits._
-import org.http4s.{HttpRoutes, Response}
+import cats.effect.*
+import com.comcast.ip4s.*
+import org.http4s.HttpRoutes
+import org.http4s.Response
+import org.http4s.dsl.io.*
+import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.implicits.*
 
 import scala.concurrent.ExecutionContext.global
-import org.http4s.blaze.server.BlazeServerBuilder
 
 object Main extends IOApp {
 
@@ -24,11 +26,12 @@ object Main extends IOApp {
     .orNotFound
 
   def run(args: List[String]): IO[ExitCode] =
-    BlazeServerBuilder[IO](global)
-      .bindHttp(3000, "0.0.0.0")
+    EmberServerBuilder
+      .default[IO]
+      .withHost(host"0.0.0.0")
+      .withPort(port"3000")
       .withHttpApp(helloWorldService)
-      .serve
-      .compile
-      .drain
+      .build
+      .useForever
       .as(ExitCode.Success)
 }


### PR DESCRIPTION
Default Http4s server/client backend is now ember (see https://http4s.org/v0.23/docs/quickstart.html). So lets benchmark this backend