### PR TITLE
khttp: use default serving strategy

### DIFF
--- a/rust/khttp/src/main.rs
+++ b/rust/khttp/src/main.rs
@@ -19,5 +19,5 @@ fn main() {
     });
 
     // serve
-    app.build().serve_epoll().unwrap();
+    app.build().serve().unwrap();
 }


### PR DESCRIPTION
Changes the serving strategy for `khttp`.

`serve_epoll` was purely optimized for the use-case of only keep-alive connections (e.g. benchmarks), `serve` should have much better throughput if tcp connections are not reused.