### PR TITLE
Update Hummingbird example

### DIFF
--- a/swift/hummingbird-framework/Package.swift
+++ b/swift/hummingbird-framework/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "server",
     platforms: [.macOS(.v14)], // This is for development on macOS
     dependencies: [
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.16.0"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
Updated swift/hummingbird-framework example app

* Update Package.swift to unblock the build system to pick up the latest minor version 2.16.0 (it was blocked at 2.0.1)
* Removed outdated compiler option `-cross-module-optimization` which is enabled by default on Swift 5.8 and later
* Adopt Swift 6 language mode by bumping swift-tools-version to 6.0
