### PR TITLE
Update Vapor example

### DIFF
--- a/swift/vapor-framework/Package.swift
+++ b/swift/vapor-framework/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,26 +6,20 @@ import PackageDescription
 let package = Package(
     name: "server",
     platforms: [
-        .macOS("10.15")
+        .macOS(.v14)
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/vapor/vapor.git", .upToNextMinor(from: "4.117.0"))
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.117.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(
+        .executableTarget(
             name: "server",
             dependencies: [
                 .product(name: "Vapor", package: "vapor")
             ],
-            swiftSettings: [
-                // Enable better optimizations when building in Release configuration. Despite the use of
-                // the `.unsafeFlags` construct required by SwiftPM, this flag is recommended for Release
-                // builds. See <https://github.com/swift-server/guides#building-for-production> for details.
-                .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
-            ]),
-            
+        ),
     ]
 )


### PR DESCRIPTION
The similar update as https://github.com/the-benchmarker/web-frameworks/pull/8759

- Updated swift-tools-version to 6.0 to run the Vapor app with Swift 6 language mode
   - Updated outdated syntax in Package.swift
- Used most common syntax for specifying dependency version 
- Removed outdated option `-cross-module-optimization`
