### PR TITLE
Fix Mezzio\Helper\ConfigProvider is registered more than once

### DIFF
--- a/php/mezzio/config/config.php
+++ b/php/mezzio/config/config.php
@@ -14,7 +14,6 @@ $cacheConfig = [
 ];
 
 $aggregator = new ConfigAggregator([
-    \Mezzio\Helper\ConfigProvider::class,
     \Mezzio\Router\FastRouteRouter\ConfigProvider::class,
     \Laminas\HttpHandlerRunner\ConfigProvider::class,
     // Include cache configuration


### PR DESCRIPTION
I was unable to reproduce the slim-swoole issue locally.