### PR TITLE
disabled cluster mode

### DIFF
--- a/javascript/brahma-firelight/app.ts
+++ b/javascript/brahma-firelight/app.ts
@@ -4,7 +4,7 @@ const app = createApp();
 
 // GET
 app.get('/', (req, res) => {
-  res.text('');
+  res.send(200);
 });
 
 app.get('/user/:id', (req, res) => {
@@ -13,7 +13,7 @@ app.get('/user/:id', (req, res) => {
 
 // POST
 app.post('/user', (req, res) => {
-  res.text('');
+  res.send(200);
 });
 
 app.listen('0.0.0.0', 3000);

--- a/javascript/brahma-firelight/cluster.ts
+++ b/javascript/brahma-firelight/cluster.ts
@@ -1,12 +1,15 @@
-// brahma-firelight v1.5.18 now supports true multi-core ⚡⚡
+// brahma-firelight v1.5.18+ now supports true multi-core ⚡⚡
 
-import { availableParallelism } from 'node:os';
+// import { availableParallelism } from 'node:os';
 
-const numCpus = availableParallelism();
+// const numCpus = availableParallelism();
 
-for (let i = 0; i < numCpus; i++) {
-  Bun.spawn(['bun', 'app.ts'], {
-    stdio: ['inherit', 'inherit', 'inherit'],
-    env: { ...process.env },
-  });
-}
+// for (let i = 0; i < numCpus; i++) {
+//   Bun.spawn(['bun', 'app.ts'], {
+//     stdio: ['inherit', 'inherit', 'inherit'],
+//     env: { ...process.env },
+//   });
+// }
+
+// disabled for now 
+import './app'

--- a/javascript/brahma-firelight/package.json
+++ b/javascript/brahma-firelight/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
   "dependencies": {
-    "brahma-firelight": "^1.5.18"
+    "brahma-firelight": "^1.5.20"
   }
 }


### PR DESCRIPTION
Well the cluster mode is disabled for now. Also i noticed that cluster setup js frameworks in your current monorepo doesn't pay off. If you take a look at express, hono and fastify obviously they perfom low in single core mode but on cluster they possess the ability to hit `3x` their current req/s. Unfortunately here its not happening.

Speaking about uws-js and ultimate-express they are c++ bindings also support so_reuseport. I guess they can even hit more req/s without your cluster setup which is killing them. I guess this runs where not done on server grade processor but a consumer grade pc which ultimately turns the table.