### PR TITLE
Update Debian, website address and ENTRYPOINT exec syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@ Gemfile.lock
 # git temporary files
 *.orig
 
-# GoLand IDE
-.idea
-
 # Temporary files
 FRAMEWORKS.yaml
 */*/.Dockerfile*
@@ -60,3 +57,8 @@ __pycache__/
 
 
 .results
+
+# IDEs configurations
+.vscode
+.idea
+.zed

--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Results
 
-Please take a look at https://web-frameworks-benchmark.netlify.app/result
+Please take a look at https://web-frameworks-benchmark.vercel.app/result

--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -32,7 +32,7 @@ RUN mix release --path release
 
 # ===============================================================================================
 
-FROM debian:bookworm-slim AS app
+FROM debian:trixie-slim AS app
 
 # Update system deps
 RUN apt-get -qq update && apt-get -qy install --no-install-recommends openssl

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -36,7 +36,7 @@ RUN go get
 RUN go build -a -ldflags '-extldflags "-static"' {{#build_tags}} -tags {{{.}}} {{/build_tags}} -o /go/bin/app ./
 
 
-FROM debian:stable
+FROM debian:trixie-slim
 
 WORKDIR /go/bin
 

--- a/haskell/Dockerfile
+++ b/haskell/Dockerfile
@@ -18,4 +18,4 @@ RUN apt-get -qq update
 RUN apt-get -qy install curl
 HEALTHCHECK CMD curl --fail http://0.0.0.0:3000 || exit 1
 
-ENTRYPOINT {{#command}}{{{.}}}{{/command}}
+ENTRYPOINT {{{command}}}

--- a/kotlin/Dockerfile
+++ b/kotlin/Dockerfile
@@ -18,5 +18,5 @@ RUN apt-get -qq update
 RUN apt-get -qy install curl
 HEALTHCHECK CMD curl --fail http://0.0.0.0:3000 || exit 1
 
-ENTRYPOINT java -server -jar /usr/src/app/build/libs/server.jar
+ENTRYPOINT ["java", "-server", "-jar", "/usr/src/app/build/libs/server.jar"]
 

--- a/nim/Dockerfile
+++ b/nim/Dockerfile
@@ -68,5 +68,5 @@ HEALTHCHECK CMD curl --fail http://0.0.0.0:3000 || exit 1
   ENTRYPOINT {{{.}}}
 {{/command}}
 {{^command}}
-  ENTRYPOINT /usr/src/app/server
+  ENTRYPOINT ["/usr/src/app/server"]
 {{/command}}


### PR DESCRIPTION
1. Update Debian base images versions to v13 (Trixie) for Elixir and Go Dockerfiles;
2. Use the `ENTRYPOINT` exec syntax in Dockerfile for Java and Nim;
3. Add IDE config directories to .gitignore;
4. Update the website address.