### PR TITLE
ci: remove 120s wait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,23 @@ jobs:
           ENGINE: ${{ matrix.engine }}
 
       - name: Wait
-        run: sleep 120
+        run: |
+          IP_FILE="${{ matrix.directory }}/ip-${{ matrix.engine }}.txt"
+          IP=$(cat $IP_FILE | tr -d '[:space:]')
 
+          echo "Waiting for http://$IP:3000/ to respond (timeout 30s)..."
+
+          SECONDS_WAITED=0
+          MAX_WAIT=30
+
+          until curl -s -f "http://$IP:3000/" > /dev/null; do
+            sleep 1
+            SECONDS_WAITED=$((SECONDS_WAITED+1))
+            if [ $SECONDS_WAITED -ge $MAX_WAIT ]; then
+              echo "Container did not become ready in $MAX_WAIT seconds!"
+              exit 1
+            fi
+          done
       - name: Test
         run: bundle exec rspec .spec
         env:


### PR DESCRIPTION
Replace the fixed 2-minute container wait with a once-per-second poll of the container under test using cURL `GET http:${IP}:3000/`, so that if the container responds, the wait stage ends immediately, and if it does not respond, it ends after 30 seconds (timeout).

In the test scenario for 12 Crystal frameworks, the build with a 120-second wait took 280 seconds ([link](https://github.com/nakrovati/web-frameworks/actions/runs/22522456308)), compared to 163 seconds ([link](https://github.com/nakrovati/web-frameworks/actions/runs/22527273739)) with a poll every second. In the test scenario for all frameworks at once, the acceleration will be approximately 20%.