### PR TITLE
refactor(js): process SIGINT and SIGTERM in clusters

### DIFF
--- a/javascript/0http-bun/cluster.ts
+++ b/javascript/0http-bun/cluster.ts
@@ -1,10 +1,23 @@
-import { availableParallelism } from 'node:os';
+import { spawn } from "bun";
 
-const numCpus = availableParallelism();
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
 
-for (let i = 0; i < numCpus; i++) {
-  Bun.spawn(['bun', 'app.ts'], {
-    stdio: ['inherit', 'inherit', 'inherit'],
-    env: { ...process.env },
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ["bun", "./app.ts"],
+    stdio: ["inherit", "inherit", "inherit"],
   });
+
+  console.log(`Worker ${buns[i].pid} started`);
 }
+
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on("SIGINT", kill);
+process.on("SIGTERM", kill);
+process.on("exit", kill);

--- a/javascript/0http/cluster.mjs
+++ b/javascript/0http/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/adonisjs-http/cluster.mjs
+++ b/javascript/adonisjs-http/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/adonisjs-slim/cluster.mjs
+++ b/javascript/adonisjs-slim/cluster.mjs
@@ -1,13 +1,20 @@
-import cluster from "node:cluster";
-import { availableParallelism } from "node:os";
+import cluster from 'node:cluster';
+import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
-  console.log(`Worker ${process.pid} running at:`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/blaze-bun/cluster.ts
+++ b/javascript/blaze-bun/cluster.ts
@@ -1,10 +1,23 @@
-import { availableParallelism } from 'node:os';
+import { spawn } from "bun";
 
-const numCpus = availableParallelism();
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
 
-for (let i = 0; i < numCpus; i++) {
-  Bun.spawn(['bun', 'app.ts'], {
-    stdio: ['inherit', 'inherit', 'inherit'],
-    env: { ...process.env },
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ["bun", "./app.ts"],
+    stdio: ["inherit", "inherit", "inherit"],
   });
+
+  console.log(`Worker ${buns[i].pid} started`);
 }
+
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on("SIGINT", kill);
+process.on("SIGTERM", kill);
+process.on("exit", kill);

--- a/javascript/blaze-node/cluster.mjs
+++ b/javascript/blaze-node/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/brahma-firelight/cluster.ts
+++ b/javascript/brahma-firelight/cluster.ts
@@ -1,15 +1,23 @@
-// brahma-firelight v1.5.18+ now supports true multi-core ⚡⚡
+import { spawn } from "bun";
 
-// import { availableParallelism } from 'node:os';
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
 
-// const numCpus = availableParallelism();
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ["bun", "./app.ts"],
+    stdio: ["inherit", "inherit", "inherit"],
+  });
 
-// for (let i = 0; i < numCpus; i++) {
-//   Bun.spawn(['bun', 'app.ts'], {
-//     stdio: ['inherit', 'inherit', 'inherit'],
-//     env: { ...process.env },
-//   });
-// }
+  console.log(`Worker ${buns[i].pid} started`);
+}
 
-// disabled for now
-import './app';
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on("SIGINT", kill);
+process.on("SIGTERM", kill);
+process.on("exit", kill);

--- a/javascript/bunicorn/cluster.ts
+++ b/javascript/bunicorn/cluster.ts
@@ -1,10 +1,23 @@
-import { availableParallelism } from 'node:os';
+import { spawn } from "bun";
 
-const numCpus = availableParallelism();
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
 
-for (let i = 0; i < numCpus; i++) {
-  Bun.spawn(['bun', 'app.ts'], {
-    stdio: ['inherit', 'inherit', 'inherit'],
-    env: { ...process.env },
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ["bun", "./app.ts"],
+    stdio: ["inherit", "inherit", "inherit"],
   });
+
+  console.log(`Worker ${buns[i].pid} started`);
 }
+
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on("SIGINT", kill);
+process.on("SIGTERM", kill);
+process.on("exit", kill);

--- a/javascript/chubbyts-uwebsockets/cluster.mjs
+++ b/javascript/chubbyts-uwebsockets/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/chubbyts/cluster.mjs
+++ b/javascript/chubbyts/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/durian.js-fastify/cluster.ts
+++ b/javascript/durian.js-fastify/cluster.ts
@@ -1,10 +1,23 @@
-import { availableParallelism } from 'node:os';
+import { spawn } from "bun";
 
-const numCpus = availableParallelism();
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
 
-for (let i = 0; i < numCpus; i++) {
-  Bun.spawn(['bun', 'src', 'main.ts'], {
-    stdio: ['inherit', 'inherit', 'inherit'],
-    env: { ...process.env },
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ["bun", "src", "main.ts"],
+    stdio: ["inherit", "inherit", "inherit"],
   });
+
+  console.log(`Worker ${buns[i].pid} started`);
 }
+
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on("SIGINT", kill);
+process.on("SIGTERM", kill);
+process.on("exit", kill);

--- a/javascript/durian.js/cluster.ts
+++ b/javascript/durian.js/cluster.ts
@@ -1,10 +1,23 @@
-import { availableParallelism } from 'node:os';
+import { spawn } from "bun";
 
-const numCpus = availableParallelism();
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
 
-for (let i = 0; i < numCpus; i++) {
-  Bun.spawn(['bun', 'src/main.ts'], {
-    stdio: ['inherit', 'inherit', 'inherit'],
-    env: { ...process.env },
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ["bun", "src", "main.ts"],
+    stdio: ["inherit", "inherit", "inherit"],
   });
+
+  console.log(`Worker ${buns[i].pid} started`);
 }
+
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on("SIGINT", kill);
+process.on("SIGTERM", kill);
+process.on("exit", kill);

--- a/javascript/elysia-bun/cluster.ts
+++ b/javascript/elysia-bun/cluster.ts
@@ -1,10 +1,23 @@
-import { availableParallelism } from 'node:os';
+import { spawn } from "bun";
 
-const numCpus = availableParallelism();
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
 
-for (let i = 0; i < numCpus; i++) {
-  Bun.spawn(['bun', 'app.ts'], {
-    stdio: ['inherit', 'inherit', 'inherit'],
-    env: { ...process.env },
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ["bun", "./app.ts"],
+    stdio: ["inherit", "inherit", "inherit"],
   });
+
+  console.log(`Worker ${buns[i].pid} started`);
 }
+
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on("SIGINT", kill);
+process.on("SIGTERM", kill);
+process.on("exit", kill);

--- a/javascript/elysia-node/cluster.mjs
+++ b/javascript/elysia-node/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/express-bun/cluster.ts
+++ b/javascript/express-bun/cluster.ts
@@ -1,10 +1,23 @@
-import { availableParallelism } from 'node:os';
+import { spawn } from "bun";
 
-const numCpus = availableParallelism();
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
 
-for (let i = 0; i < numCpus; i++) {
-  Bun.spawn(['bun', 'app.ts'], {
-    stdio: ['inherit', 'inherit', 'inherit'],
-    env: { ...process.env },
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ["bun", "./app.ts"],
+    stdio: ["inherit", "inherit", "inherit"],
   });
+
+  console.log(`Worker ${buns[i].pid} started`);
 }
+
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on("SIGINT", kill);
+process.on("SIGTERM", kill);
+process.on("exit", kill);

--- a/javascript/express/cluster.mjs
+++ b/javascript/express/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/fastify-bun/cluster.ts
+++ b/javascript/fastify-bun/cluster.ts
@@ -1,10 +1,23 @@
-import { availableParallelism } from 'node:os';
+import { spawn } from "bun";
 
-const numCpus = availableParallelism();
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
 
-for (let i = 0; i < numCpus; i++) {
-  Bun.spawn(['bun', 'app.ts'], {
-    stdio: ['inherit', 'inherit', 'inherit'],
-    env: { ...process.env },
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ["bun", "./app.ts"],
+    stdio: ["inherit", "inherit", "inherit"],
   });
+
+  console.log(`Worker ${buns[i].pid} started`);
 }
+
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on("SIGINT", kill);
+process.on("SIGTERM", kill);
+process.on("exit", kill);

--- a/javascript/fastify/cluster.mjs
+++ b/javascript/fastify/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/feathersjs/cluster.mjs
+++ b/javascript/feathersjs/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/foxify/cluster.mjs
+++ b/javascript/foxify/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/fyrejet/cluster.mjs
+++ b/javascript/fyrejet/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/h3/cluster.mjs
+++ b/javascript/h3/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/hapi/cluster.mjs
+++ b/javascript/hapi/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/hono-node/cluster.mjs
+++ b/javascript/hono-node/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/hono/cluster.ts
+++ b/javascript/hono/cluster.ts
@@ -1,10 +1,23 @@
-import { availableParallelism } from 'node:os';
+import { spawn } from "bun";
 
-const numCpus = availableParallelism();
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
 
-for (let i = 0; i < numCpus; i++) {
-  Bun.spawn(['bun', 'app.ts'], {
-    stdio: ['inherit', 'inherit', 'inherit'],
-    env: { ...process.env },
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ["bun", "./app.ts"],
+    stdio: ["inherit", "inherit", "inherit"],
   });
+
+  console.log(`Worker ${buns[i].pid} started`);
 }
+
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on("SIGINT", kill);
+process.on("SIGTERM", kill);
+process.on("exit", kill);

--- a/javascript/hyper-express/cluster.mjs
+++ b/javascript/hyper-express/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/ignisia/cluster.ts
+++ b/javascript/ignisia/cluster.ts
@@ -1,10 +1,23 @@
-import { availableParallelism } from 'node:os';
+import { spawn } from "bun";
 
-const numCpus = availableParallelism();
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
 
-for (let i = 0; i < numCpus; i++) {
-  Bun.spawn(['bun', 'app.ts'], {
-    stdio: ['inherit', 'inherit', 'inherit'],
-    env: { ...process.env },
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ["bun", "./app.ts"],
+    stdio: ["inherit", "inherit", "inherit"],
   });
+
+  console.log(`Worker ${buns[i].pid} started`);
 }
+
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on("SIGINT", kill);
+process.on("SIGTERM", kill);
+process.on("exit", kill);

--- a/javascript/iotjs-express/cluster.mjs
+++ b/javascript/iotjs-express/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/koa-bun/cluster.ts
+++ b/javascript/koa-bun/cluster.ts
@@ -1,12 +1,23 @@
-import cluster from 'node:cluster';
-import os from 'node:os';
+import { spawn } from "bun";
 
-const cpus = os.availableParallelism();
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
 
-if (cpus > 1 && cluster.isPrimary) {
-  for (let i = 0; i < cpus; i++) {
-    cluster.fork();
-  }
-} else {
-  await import('./app.ts');
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ["bun", "./app.ts"],
+    stdio: ["inherit", "inherit", "inherit"],
+  });
+
+  console.log(`Worker ${buns[i].pid} started`);
 }
+
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on("SIGINT", kill);
+process.on("SIGTERM", kill);
+process.on("exit", kill);

--- a/javascript/koa/cluster.mjs
+++ b/javascript/koa/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/low-http-server/cluster.mjs
+++ b/javascript/low-http-server/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/mesh/cluster.mjs
+++ b/javascript/mesh/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/moleculer/cluster.mjs
+++ b/javascript/moleculer/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/muneem/cluster.mjs
+++ b/javascript/muneem/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/nestjs-express/cluster.mjs
+++ b/javascript/nestjs-express/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/nestjs-fastify/cluster.mjs
+++ b/javascript/nestjs-fastify/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/oak-bun/cluster.ts
+++ b/javascript/oak-bun/cluster.ts
@@ -1,10 +1,23 @@
-import { availableParallelism } from 'node:os';
+import { spawn } from "bun";
 
-const numCpus = availableParallelism();
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
 
-for (let i = 0; i < numCpus; i++) {
-  Bun.spawn(['bun', 'app.ts'], {
-    stdio: ['inherit', 'inherit', 'inherit'],
-    env: { ...process.env },
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ["bun", "./app.ts"],
+    stdio: ["inherit", "inherit", "inherit"],
   });
+
+  console.log(`Worker ${buns[i].pid} started`);
 }
+
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on("SIGINT", kill);
+process.on("SIGTERM", kill);
+process.on("exit", kill);

--- a/javascript/polka/cluster.mjs
+++ b/javascript/polka/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/polkadot/cluster.mjs
+++ b/javascript/polkadot/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/pxe/cluster.mjs
+++ b/javascript/pxe/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/rayo/cluster.mjs
+++ b/javascript/rayo/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/restana/cluster.mjs
+++ b/javascript/restana/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/restify/cluster.mjs
+++ b/javascript/restify/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/routejs/cluster.mjs
+++ b/javascript/routejs/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/sails/cluster.mjs
+++ b/javascript/sails/cluster.mjs
@@ -4,7 +4,7 @@ import { exec } from "child_process"
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }

--- a/javascript/sifrr/cluster.mjs
+++ b/javascript/sifrr/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/spliffy/cluster.mjs
+++ b/javascript/spliffy/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/tinyhttp/cluster.mjs
+++ b/javascript/tinyhttp/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/totaljs/cluster.mjs
+++ b/javascript/totaljs/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/ultimate-express/cluster.mjs
+++ b/javascript/ultimate-express/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }

--- a/javascript/vixeny-bun/cluster.ts
+++ b/javascript/vixeny-bun/cluster.ts
@@ -1,10 +1,23 @@
-import { availableParallelism } from 'node:os';
+import { spawn } from "bun";
 
-const numCpus = availableParallelism();
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
 
-for (let i = 0; i < numCpus; i++) {
-  Bun.spawn(['bun', 'app.ts'], {
-    stdio: ['inherit', 'inherit', 'inherit'],
-    env: { ...process.env },
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ["bun", "./app.ts"],
+    stdio: ["inherit", "inherit", "inherit"],
   });
+
+  console.log(`Worker ${buns[i].pid} started`);
 }
+
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on("SIGINT", kill);
+process.on("SIGTERM", kill);
+process.on("exit", kill);

--- a/javascript/yume-server/cluster.mjs
+++ b/javascript/yume-server/cluster.mjs
@@ -3,10 +3,18 @@ import { availableParallelism } from 'node:os';
 
 const numCpus = availableParallelism();
 
-if (numCpus > 1 && cluster.isPrimary) {
+if (cluster.isPrimary) {
   for (let i = 0; i < numCpus; i++) {
     cluster.fork();
   }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 } else {
   await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
 }


### PR DESCRIPTION
Rewrite the Bun cluster code using the Bun API and add `SIGINT `and `SIGTERM` handling to clusters - now stopping Docker containers with `ctrl+c`, via `docker stop {container_id}`, or the Docker GUI will work.