### PR TITLE
ci: skip test phase if matrix is empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ jobs:
   matrix:
     runs-on: ubuntu-latest
 
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -32,17 +35,15 @@ jobs:
         env:
           FILES: ${{ steps.file_changes.outputs.files }}
 
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-
   test:
     needs: matrix
+    if: ${{ fromJson(needs.matrix.outputs.matrix).include[0] != null }}
 
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.matrix.outputs.matrix)}}
+      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
 
     steps:
       - name: Checkout
@@ -64,8 +65,7 @@ jobs:
         run: bundle exec rake config
 
       - name: Build
-        run: |
-          make "build"  -f "${DIRECTORY}/.Makefile"
+        run: make "build" -f "${DIRECTORY}/.Makefile"
         env:
           DIRECTORY: ${{ matrix.directory }}
           ENGINE: ${{ matrix.engine }}
@@ -73,7 +73,7 @@ jobs:
       - name: Wait for framework HTTP readiness
         run: |
           IP_FILE="${{ matrix.directory }}/ip-${{ matrix.engine }}.txt"
-          IP=$(cat $IP_FILE | tr -d '[:space:]')
+          IP=$(cat "$IP_FILE" | tr -d '[:space:]')
 
           echo "Waiting for http://$IP:3000/ to respond (timeout 30s)..."
 


### PR DESCRIPTION
Add a ‘test’ skip if the matrix is empty.

Currently, if the matrix file is empty (for example, if README.md, Rakefile, or another file that isn't part of a framework has been modified), the ‘test’ stage terminates with the error  `CI
Error when evaluating ‘strategy’ for job ‘test’. .github/workflows/ci.yml (Line: 45, Col: 15): matrix must define at least one vector`, the workflow is marked as failed, and an email is sent with the subject `[the-benchmarker/web-frameworks] PR run failed: CI - <PR title> (<commit hash>)`.