### PR TITLE
Update Robyn to 0.82.1, Python to 3.14

### DIFF
--- a/python/robyn/config.yaml
+++ b/python/robyn/config.yaml
@@ -1,7 +1,7 @@
 framework:
   website: robyn.tech
   github: sparckles/robyn
-  version: 0.82
+  version: 0.82.1
 
   engines:
     - robyn
@@ -19,7 +19,7 @@ framework:
     - rustup default nightly
 
 language:
-  version: 3.13
+  version: 3.14
   engines:
     robyn:
       command: python /usr/src/app/server.py --workers=$(nproc) --processes=$(nproc) --log-level=CRITICAL

--- a/python/robyn/pyproject.toml
+++ b/python/robyn/pyproject.toml
@@ -7,4 +7,4 @@ requires = ["flit_core"]
 name='server'
 version = '1.0.0'
 description = "Simple benchmark implementation"
-dependencies = ["robyn>=0.82,<0.83"]
+dependencies = ["robyn>=0.82.1,<0.83"]


### PR DESCRIPTION
## Summary
- Bump Robyn framework version from 0.82 to 0.82.1 (fixes CORS header duplication regression)
- Update Python version from 3.13 to 3.14
- Update pyproject.toml dependency constraint to `robyn>=0.82.1,<0.83`

## Release notes
https://github.com/sparckles/Robyn/releases/tag/v0.82.1


Made with [Cursor](https://cursor.com)