### PR TITLE
Docker - show container errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
       - name: Wait for framework HTTP readiness
         run: |
           IP_FILE="${{ matrix.directory }}/ip-${{ matrix.engine }}.txt"
-          IP=$(cat "$IP_FILE" | tr -d '[:space:]')
+          CID_FILE="${{ matrix.directory }}/cid-${{ matrix.engine }}.txt"
+          IP=$(cat $IP_FILE | tr -d '[:space:]')
 
           echo "Waiting for http://$IP:3000/ to respond (timeout 30s)..."
 
@@ -85,6 +86,8 @@ jobs:
             SECONDS_WAITED=$((SECONDS_WAITED+1))
             if [ $SECONDS_WAITED -ge $MAX_WAIT ]; then
               echo "Container did not become ready in $MAX_WAIT seconds!"
+              echo "---- Container logs ----"
+              docker logs $(cat $CID_FILE) || true
               exit 1
             fi
           done

--- a/nim/supranim/config.yaml
+++ b/nim/supranim/config.yaml
@@ -8,3 +8,7 @@ framework:
 
 build_deps:
   - libevent-dev
+  - libpcre2-dev
+
+runtime_deps:
+  - libpcre2-dev


### PR DESCRIPTION
Adding:
```yaml
      - name: Wait for framework HTTP readiness
        run: |
          IP_FILE="${{ matrix.directory }}/ip-${{ matrix.engine }}.txt"
          CID_FILE="${{ matrix.directory }}/cid-${{ matrix.engine }}.txt"
          IP=$(cat $IP_FILE | tr -d '[:space:]')

          echo "Waiting for http://$IP:3000/ to respond (timeout 30s)..."

          SECONDS_WAITED=0
          MAX_WAIT=30

          until curl -s -f "http://$IP:3000/" > /dev/null; do
            sleep 1
            SECONDS_WAITED=$((SECONDS_WAITED+1))
            if [ $SECONDS_WAITED -ge $MAX_WAIT ]; then
              echo "Container did not become ready in $MAX_WAIT seconds!"
              echo "---- Container logs ----"
              docker logs $(cat $CID_FILE) || true
              exit 1
            fi
          done
```


Will output container errors, for example:
```
Waiting for http://:3000/ to respond (timeout 30s)...
Container did not become ready in 30 seconds!
---- Container logs ----
could not load: libpcre.so(.3|.1|)
(compile with -d:nimDebugDlOpen for more information)
```