### PR TITLE
[add] gogo benchmark

### DIFF
--- a/go/config.yaml
+++ b/go/config.yaml
@@ -6,6 +6,8 @@ language:
       command: /go/bin/app
     fasthttp:
       command: /go/bin/app
+    gogo:
+      command: /go/bin/app
 
 framework:
   engines:

--- a/go/gogo.Dockerfile
+++ b/go/gogo.Dockerfile
@@ -1,0 +1,73 @@
+{{#language.version}}
+  FROM golang:{{{.}}} AS build
+{{/language.version}}
+{{^language.version}}
+  FROM golang:1.26 AS build
+{{/language.version}}
+
+WORKDIR /go/src/app
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get -qq update && \
+  apt-get -qy install --no-install-recommends \
+    build-essential \
+    zlib1g-dev && \
+  rm -rf /var/lib/apt/lists/*
+
+ENV CGO_ENABLED=1 \
+  GOOS=linux \
+  GOARCH={{#architecture}}{{{.}}}{{/architecture}}
+
+{{#if.architecture.amd64}}
+  # This compile with v3 micoarchitecture, since used proc is zen2 compatible ( AMD Ryzen 7 5700U)
+  # See https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels
+  ENV GOAMD64=v3
+{{/if.architecture.amd64}}
+
+{{#if.architecture.arm64}}
+  # Use arm 8.5 instrctions set
+  # See https://en.wikipedia.org/wiki/Apple_M1
+  ENV GOARM64=v8.5
+{{/if.architecture.arm64}}
+
+{{#files}}
+  COPY '{{source}}' '{{target}}'
+{{/files}}
+
+{{#bootstrap}}
+  RUN {{{.}}}
+{{/bootstrap}}
+
+RUN --mount=type=cache,id=gomod-{{language.version}},target=/go/pkg/mod \
+  go get
+
+RUN --mount=type=cache,id=gomod-{{language.version}},target=/go/pkg/mod \
+  --mount=type=cache,id=gobuild-{{language.version}},target=/root/.cache/go-build \
+  go build -trimpath {{#build_tags}} -tags {{{.}}} {{/build_tags}} -o /go/bin/app ./
+
+
+
+FROM debian:trixie-slim
+
+WORKDIR /go/bin
+
+RUN apt-get -qq update && \
+  apt-get -qy install --no-install-recommends \
+    curl \
+    libstdc++6 \
+    zlib1g && \
+  rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /go/bin/app /go/bin/app
+
+{{#environment}}
+  ENV {{{.}}}
+{{/environment}}
+
+{{#static_files}}
+  COPY '{{source}}' '{{target}}'
+{{/static_files}}
+
+HEALTHCHECK CMD curl --fail http://0.0.0.0:3000 || exit 1
+
+ENTRYPOINT {{{command}}}

--- a/go/gogo/config.yaml
+++ b/go/gogo/config.yaml
@@ -1,0 +1,9 @@
+framework:
+  github: Snocko-main/gogo
+  version: 0.1.0
+
+  build_tags:
+    - gogo
+
+  engines:
+    - gogo

--- a/go/gogo/go.mod
+++ b/go/gogo/go.mod
@@ -1,0 +1,3 @@
+module main
+
+require github.com/Snocko-main/gogo v0.1.0

--- a/go/gogo/main.go
+++ b/go/gogo/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"log"
+	"runtime"
+
+	gogo "github.com/Snocko-main/gogo"
+)
+
+func main() {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	app, err := gogo.NewApp()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer app.Close()
+
+	app.Get("/", gogo.Reply{Status: 200})
+
+	app.Get("/user/:id", func(res *gogo.Response, req *gogo.Request) {
+		res.Send(200, "text/plain; charset=utf-8", req.Parameter(0))
+	})
+
+	app.Post("/user", func(res *gogo.Response, req *gogo.Request) {
+		res.Send(200, "", "")
+	})
+
+	if !app.Listen(3000) {
+		log.Fatal("failed to listen on :3000")
+	}
+
+	app.Run()
+}


### PR DESCRIPTION
## What changed

- Add a Go/gogo benchmark implementation for the required route contract:
  - `GET /` returns 200 with an empty body
  - `GET /user/:id` returns the route parameter
  - `POST /user` returns 200 with an empty body
- Register a `gogo` Go engine so the benchmark generator can select a framework-specific Dockerfile.
- Add a `go/gogo.Dockerfile` that enables cgo, installs native zlib build headers, builds with the `gogo` tag, and installs runtime libraries needed by the native binary.

## Validation

- `gofmt -w go/gogo/main.go`
- `git diff --cached --check`
- `ruby -ryaml -e 'ARGV.each { |f| YAML.safe_load(File.read(f)); puts "ok #{f}" }' go/config.yaml go/gogo/config.yaml`
- `CGO_ENABLED=1 go test -tags gogo ./...` in the gogo source checkout
- `CGO_ENABLED=1 go run -mod=mod -tags gogo .` from `go/gogo`, then checked:
  - `GET /` -> 200, empty body
  - `GET /user/0` -> 200, body `0`
  - `POST /user` -> 200, empty body

## Notes

I could not run `bundle exec rake config` or a Docker build locally because this machine only has macOS system Ruby 2.6 for the repo's Ruby 3+ rake code and does not have Docker installed. The PR is opened as a draft so CI can validate the generated Docker path before review.
