### PR TITLE
Update module github.com/Snocko-main/gogo to v1.0.1

### DIFF
--- a/go/gogo/config.yaml
+++ b/go/gogo/config.yaml
@@ -1,6 +1,6 @@
 framework:
   github: Snocko-main/gogo
-  version: 0.1.0
+  version: 1.0.1
 
   build_tags:
     - gogo

--- a/go/gogo/go.mod
+++ b/go/gogo/go.mod
@@ -1,3 +1,3 @@
 module main
 
-require github.com/Snocko-main/gogo v0.1.0
+require github.com/Snocko-main/gogo v1.0.1


### PR DESCRIPTION
Hi @waghanza, gogo has reached v1.0.1, so this updates the benchmark metadata and Go module requirement to the stable release.

This supersedes #9442, which is still targeting v0.9.0.

Changes:
- update `go/gogo/config.yaml` framework version from `0.1.0` to `1.0.1`
- update `go/gogo/go.mod` from `github.com/Snocko-main/gogo v0.1.0` to `v1.0.1`

Note: v1.0.1 includes the Linux/glibc cgo fix for `syscall(SYS_gettid)`, so no benchmark-side bootstrap workaround is needed.

Verification:
- `go list -m -versions github.com/Snocko-main/gogo` shows `v1.0.1`
- temp module build without custom CGO flags: `go get`, then `CGO_ENABLED=1 go build -tags gogo ./...`

Local note: Docker is not available on my machine, so the PR CI should verify the Linux/Docker build path.