### PR TITLE
Add Veloce (Python ASGI framework)

### DIFF
--- a/python/veloce/config.yaml
+++ b/python/veloce/config.yaml
@@ -1,0 +1,9 @@
+framework:
+  website: veloceframework.com
+  version: 0.8
+
+  engines:
+    - uvicorn
+    - hypercorn
+    - daphne
+    - granian

--- a/python/veloce/pyproject.toml
+++ b/python/veloce/pyproject.toml
@@ -1,0 +1,10 @@
+
+[build-system]
+build-backend = "flit_core.buildapi"
+requires = ["flit_core"]
+
+[project]
+name='server'
+version = '1.0.0'
+description = "Simple benchmark implementation"
+dependencies = ["veloceframework>=0.8,<0.9"]

--- a/python/veloce/server.py
+++ b/python/veloce/server.py
@@ -1,0 +1,18 @@
+from veloce import PlainTextResponse, Veloce
+
+app = Veloce()
+
+
+@app.get("/")
+async def index():
+    return PlainTextResponse(content="")
+
+
+@app.get("/user/{id}")
+async def get_user(id: int):
+    return PlainTextResponse(content=f"{id}")
+
+
+@app.post("/user")
+async def create_user():
+    return PlainTextResponse(content="")


### PR DESCRIPTION
Adds **Veloce**, a from-scratch async Python web framework (ASGI-native), as `python/veloce/`.

- Routes conform to the spec: `GET /` → 200 empty, `GET /user/{id}` → 200 with the id, `POST /user` → 200 empty (via `PlainTextResponse`).
- Engines: `uvicorn`, `hypercorn`, `daphne`, `granian` — each smoke-tested to boot Veloce and serve the three routes.
- Dependency pinned to `veloceframework>=0.8,<0.9` (the PyPI package name is `veloceframework`).

Links: https://veloceframework.com · https://pypi.org/project/veloceframework/ · https://github.com/Lokesh-Tallapaneni/veloce