### PR TITLE
Ignore Claude Code local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ __pycache__/
 .vscode
 .idea
 .zed
+
+# Claude Code local config
+.claude/
+.mcp.json


### PR DESCRIPTION
Add .claude/ and .mcp.json to .gitignore so local Claude Code editor config and the machine-specific MCP server config (contains an absolute local path) are not tracked by git.