### PR TITLE
Add fulmine (JavaScript)

### DIFF
--- a/javascript/fulmine/app.mjs
+++ b/javascript/fulmine/app.mjs
@@ -1,0 +1,19 @@
+import express from 'fulmine.js';
+
+const app = express();
+
+app.set('etag', false);
+
+app.get('/', function (req, res) {
+  res.send('');
+});
+
+app.get('/user/:id', function (req, res) {
+  res.send(req.params.id);
+});
+
+app.post('/user', function (req, res) {
+  res.send('');
+});
+
+app.listen(3000);

--- a/javascript/fulmine/cluster.mjs
+++ b/javascript/fulmine/cluster.mjs
@@ -1,0 +1,20 @@
+import cluster from 'node:cluster';
+import { availableParallelism } from 'node:os';
+
+const numCpus = availableParallelism();
+
+if (cluster.isPrimary) {
+  for (let i = 0; i < numCpus; i++) {
+    cluster.fork();
+  }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+} else {
+  await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
+}

--- a/javascript/fulmine/config.yaml
+++ b/javascript/fulmine/config.yaml
@@ -1,0 +1,6 @@
+framework:
+  github: nigrosimone/fulmine.js
+  version: 5.0
+
+  engines:
+    - uwebsockets

--- a/javascript/fulmine/package.json
+++ b/javascript/fulmine/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "fulmine.js": "^5.0.0"
+  },
+  "type": "module"
+}


### PR DESCRIPTION
Adds **fulmine** ([fulmine.js](https://www.npmjs.com/package/fulmine.js)), an Express 5 compatible framework built on µWebSockets.js

The entry mirrors the `javascript/express` one: same three routes, `etag` off, `cluster.mjs` for multi-core, engine declared as `uwebsockets` in `config.yaml`. The dependency is pinned `^5.0.0` so rebuilds track the latest 5.x.

Verified locally against the published package: `GET /` answers 200 with an empty body, `GET /user/42` answers `42`, `POST /user` answers 200 with an empty body.
