### PR TITLE
Add nifra (JavaScript)

### DIFF
--- a/javascript/nifra-bun/app.ts
+++ b/javascript/nifra-bun/app.ts
@@ -1,0 +1,7 @@
+import { server } from '@nifrajs/core/server';
+
+server()
+  .get('/', () => new Response(''))
+  .get('/user/:id', (c) => new Response(c.params.id))
+  .post('/user', () => new Response(''))
+  .listen(3000, { reusePort: true });

--- a/javascript/nifra-bun/cluster.ts
+++ b/javascript/nifra-bun/cluster.ts
@@ -1,0 +1,23 @@
+import { spawn } from 'bun';
+
+const cpus = navigator.hardwareConcurrency;
+const buns = new Array(cpus);
+
+for (let i = 0; i < cpus; i++) {
+  buns[i] = spawn({
+    cmd: ['bun', './app.ts'],
+    stdio: ['inherit', 'inherit', 'inherit'],
+  });
+
+  console.log(`Worker ${buns[i].pid} started`);
+}
+
+function kill() {
+  for (const bun of buns) {
+    bun.kill();
+  }
+}
+
+process.on('SIGINT', kill);
+process.on('SIGTERM', kill);
+process.on('exit', kill);

--- a/javascript/nifra-bun/config.yaml
+++ b/javascript/nifra-bun/config.yaml
@@ -1,0 +1,5 @@
+framework:
+  website: nifra.dev
+  version: 2.8
+  engines:
+    - bun

--- a/javascript/nifra-bun/package.json
+++ b/javascript/nifra-bun/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@nifrajs/core": "~2.8.2"
+  }
+}

--- a/javascript/nifra-node/app.mjs
+++ b/javascript/nifra-node/app.mjs
@@ -1,0 +1,9 @@
+import { server } from '@nifrajs/core/server';
+import { serve } from '@nifrajs/node';
+
+const app = server()
+  .get('/', () => new Response(''))
+  .get('/user/:id', (c) => new Response(c.params.id))
+  .post('/user', () => new Response(''));
+
+await serve(app, { port: 3000 });

--- a/javascript/nifra-node/cluster.mjs
+++ b/javascript/nifra-node/cluster.mjs
@@ -1,0 +1,20 @@
+import cluster from 'node:cluster';
+import { availableParallelism } from 'node:os';
+
+const numCpus = availableParallelism();
+
+if (cluster.isPrimary) {
+  for (let i = 0; i < numCpus; i++) {
+    cluster.fork();
+  }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+} else {
+  await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
+}

--- a/javascript/nifra-node/config.yaml
+++ b/javascript/nifra-node/config.yaml
@@ -1,0 +1,3 @@
+framework:
+  website: nifra.dev
+  version: 2.8

--- a/javascript/nifra-node/package.json
+++ b/javascript/nifra-node/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@nifrajs/core": "~2.8.2",
+    "@nifrajs/node": "~2.8.2"
+  }
+}


### PR DESCRIPTION
Adds nifra (https://nifra.dev), a full-stack TypeScript framework, with two entries following the existing conventions:

- javascript/nifra-bun - Bun engine (nifra's primary runtime), reusePort cluster like elysia-bun
- javascript/nifra-node - Node engine via the @nifrajs/node adapter, cluster.mjs like hono-node

Both implement the three required routes and were verified locally against the published npm packages (@nifrajs/core 2.8.2): GET / returns 200 with an empty body, GET /user/:id returns the id, POST /user returns 200 with an empty body.