### PR TITLE
Fix guildenstern, use `lvlNone` instead of `NONE`

### DIFF
--- a/nim/guildenstern/server.nim
+++ b/nim/guildenstern/server.nim
@@ -9,7 +9,7 @@ proc handle() =
       let id = getUri()[6 .. ^1]
       reply(id)
   except: reply(Http500)
-  
-let server = newHttpServer(handle, loglevel = NONE, contenttype = NoBody)
+
+let server = newHttpServer(handle, loglevel = lvlNone, contenttype = NoBody)
 if not dispatcher.start(server, 3000, ThreadCount, ThreadCount): quit()
 joinThread(server.thread)


### PR DESCRIPTION
Fixes the compile error, should've been `lvlNone` (e.g. https://github.com/olliNiinivaara/GuildenStern/blob/9129b1af438a98c226a13f9fc0e7f9b788535f7e/examples/websockettest.nim#L63)

Unblocks guildenstern for #9648
