### PR TITLE
Add cps-http

### DIFF
--- a/nim/cps-http/README.md
+++ b/nim/cps-http/README.md
@@ -1,0 +1,23 @@
+# CPS HTTP benchmark adapter
+
+This adapter benchmarks the full CPS HTTP/1.1 parser and router with the
+repository's allocation-light accept API. It implements the three routes
+required by `web-frameworks`, compiles with ARC, LTO, and native CPU tuning,
+and runs one shard-local reactor thread per visible CPU. Each thread owns its
+router, event loop, listener, and connections; `SO_REUSEPORT` distributes
+accepts without a shared scheduler on the HTTP data path.
+
+Generate the manifests and run the official benchmark on a native Linux host:
+
+```sh
+CONCURRENCIES=64,256,512 \
+ROUTES=GET:/,GET:/user/0,POST:/user \
+bundle exec rake config
+./run.sh nim/cps-http
+```
+
+The official provider addresses the server through its Docker bridge IP. That
+topology is not reachable from the macOS host under Docker Desktop, so macOS
+container-client runs are diagnostic only and must not be submitted as
+official results. The official route contract can still be run there with
+`make -f nim/cps-http/.Makefile test` when the server is reachable.

--- a/nim/cps-http/config.yaml
+++ b/nim/cps-http/config.yaml
@@ -1,0 +1,31 @@
+framework:
+  github: gabearro/cps-http
+  version: 1.0.0
+  engines:
+    - multiprocess
+
+# The CPS event loop is deliberately single-threaded. Run one independent,
+# SO_REUSEPORT-backed worker per visible CPU, as production process managers do.
+# CPS_WORKERS remains available for CPU-quota-aware benchmark environments.
+language:
+  engines:
+    multiprocess:
+      command:
+        - /bin/sh
+        - -c
+        - 'workers="${CPS_WORKERS:-$(getconf _NPROCESSORS_ONLN)}"; pids=""; trap ''kill $pids 2>/dev/null; wait'' TERM INT; i=0; while [ "$i" -lt "$workers" ]; do /usr/src/app/server & pids="$pids $!"; i=$((i + 1)); done; wait'
+
+# The suite's Nim image already adds release mode, speed optimization, and LTO.
+# Danger mode removes runtime checks from the hot path, ARC avoids tracing-GC
+# work, and native CPU tuning lets the compiler use the benchmark host ISA.
+build_opts:
+  - "-d:danger"
+  - "--mm:arc"
+  - "--passC:-march=native"
+  - "--passC:-mtune=native"
+
+build_with:
+  - "nimble install -y https://github.com/gabearro/cps-runtime@#dbacd9d0e96db5b5ecf80f64362a0026bd3ec4da"
+  - "nimble install -y https://github.com/gabearro/cps-tls@#a97a50593d920f1331563382b41189394115e5ca"
+  - "nimble install -y https://github.com/gabearro/cps-quic@#e11fac12e4906a8e31d2c29fcd24d50cd3c0a428"
+  - "nimble install -y https://github.com/gabearro/cps-http@#b22542cc1d7f6c55bf29c6bf1e6ed88de3365f4c"

--- a/nim/cps-http/config.yaml
+++ b/nim/cps-http/config.yaml
@@ -1,31 +1,29 @@
 framework:
   github: gabearro/cps-http
-  version: 1.0.0
+  version: 1.0
   engines:
-    - multiprocess
+    - multithreaded
 
-# The CPS event loop is deliberately single-threaded. Run one independent,
-# SO_REUSEPORT-backed worker per visible CPU, as production process managers do.
-# CPS_WORKERS remains available for CPU-quota-aware benchmark environments.
+# Each reactor thread owns its event loop, router, listener, and connections.
+# SO_REUSEPORT distributes accepts across the shard-local reactors without a
+# shared scheduler or cross-thread work on the HTTP data path.
 language:
   engines:
-    multiprocess:
-      command:
-        - /bin/sh
-        - -c
-        - 'workers="${CPS_WORKERS:-$(getconf _NPROCESSORS_ONLN)}"; pids=""; trap ''kill $pids 2>/dev/null; wait'' TERM INT; i=0; while [ "$i" -lt "$workers" ]; do /usr/src/app/server & pids="$pids $!"; i=$((i + 1)); done; wait'
+    multithreaded:
+      command: /usr/src/app/server
 
 # The suite's Nim image already adds release mode, speed optimization, and LTO.
 # Danger mode removes runtime checks from the hot path, ARC avoids tracing-GC
 # work, and native CPU tuning lets the compiler use the benchmark host ISA.
 build_opts:
   - "-d:danger"
+  - "--threads:on"
   - "--mm:arc"
   - "--passC:-march=native"
   - "--passC:-mtune=native"
 
 build_with:
-  - "nimble install -y https://github.com/gabearro/cps-runtime@#dbacd9d0e96db5b5ecf80f64362a0026bd3ec4da"
-  - "nimble install -y https://github.com/gabearro/cps-tls@#a97a50593d920f1331563382b41189394115e5ca"
-  - "nimble install -y https://github.com/gabearro/cps-quic@#e11fac12e4906a8e31d2c29fcd24d50cd3c0a428"
-  - "nimble install -y https://github.com/gabearro/cps-http@#b22542cc1d7f6c55bf29c6bf1e6ed88de3365f4c"
+  - "nimble install -y https://github.com/gabearro/cps-runtime@#v1.1.0"
+  - "nimble install -y https://github.com/gabearro/cps-tls@#v1.0.1"
+  - "nimble install -y https://github.com/gabearro/cps-quic@#v1.0.1"
+  - "nimble install -y https://github.com/gabearro/cps-http@#v1.0.1"

--- a/nim/cps-http/server.nim
+++ b/nim/cps-http/server.nim
@@ -1,20 +1,9 @@
 import cps/runtime
-import cps/transform
-import cps/eventloop
+import cps/reactorpool
 import cps/io/tcp
 import cps/io/streams
 import cps/http/server/dsl
 import cps/http/server/http1
-
-let handler = router:
-  get "/":
-    respond 200
-
-  get "/user/{id}":
-    respond 200, pathParams["id"]
-
-  post "/user":
-    respond 200
 
 proc startAccepting(listener: TcpListener, handler: HttpHandler) =
   let config = HttpServerConfig()
@@ -22,12 +11,20 @@ proc startAccepting(listener: TcpListener, handler: HttpHandler) =
     discard handleHttp1Connection(client.AsyncStream, config, handler)
   )
 
-proc main() =
-  let listener = tcpListen("0.0.0.0", 3000, reusePort = true,
-                           deferAcceptSeconds = 1, noDelay = true)
-  startAccepting(listener, handler)
-  let loop = getEventLoop()
-  while true:
-    loop.tick()
+proc startShard(shardId: int) {.gcsafe.} =
+  {.cast(gcsafe).}:
+    let handler = router:
+      get "/":
+        respond 200
 
-main()
+      get "/user/{id}":
+        respond 200, pathParams["id"]
+
+      post "/user":
+        respond 200
+
+    let listener = tcpListen("0.0.0.0", 3000, reusePort = true,
+                             deferAcceptSeconds = 1, noDelay = true)
+    startAccepting(listener, handler)
+
+runReactorPool(startShard)

--- a/nim/cps-http/server.nim
+++ b/nim/cps-http/server.nim
@@ -1,0 +1,33 @@
+import cps/runtime
+import cps/transform
+import cps/eventloop
+import cps/io/tcp
+import cps/io/streams
+import cps/http/server/dsl
+import cps/http/server/http1
+
+let handler = router:
+  get "/":
+    respond 200
+
+  get "/user/{id}":
+    respond 200, pathParams["id"]
+
+  post "/user":
+    respond 200
+
+proc startAccepting(listener: TcpListener, handler: HttpHandler) =
+  let config = HttpServerConfig()
+  listener.acceptEach(proc(client: TcpStream) =
+    discard handleHttp1Connection(client.AsyncStream, config, handler)
+  )
+
+proc main() =
+  let listener = tcpListen("0.0.0.0", 3000, reusePort = true,
+                           deferAcceptSeconds = 1, noDelay = true)
+  startAccepting(listener, handler)
+  let loop = getEventLoop()
+  while true:
+    loop.tick()
+
+main()

--- a/nim/cps-http/server.nimble
+++ b/nim/cps-http/server.nimble
@@ -1,4 +1,4 @@
-version = "1.0.0"
+version = "1.0.1"
 author = "Gabriel Arroyo"
 description = "CPS HTTP implementation for web-frameworks"
 license = "MIT"

--- a/nim/cps-http/server.nimble
+++ b/nim/cps-http/server.nimble
@@ -1,0 +1,6 @@
+version = "1.0.0"
+author = "Gabriel Arroyo"
+description = "CPS HTTP implementation for web-frameworks"
+license = "MIT"
+
+requires "nim >= 2.0.0"


### PR DESCRIPTION
Adds [cps-http](https://github.com/gabearro/cps-http), an HTTP/1.1, HTTP/2, and HTTP/3 implementation built on the CPS Nim runtime.

The benchmark adapter exercises the full HTTP/1.1 parser and router. Since each CPS event loop is deliberately single-threaded, the container runs one `SO_REUSEPORT` worker per visible CPU, with `CPS_WORKERS` available for CPU-quota-aware deployments.

