### PR TITLE
Use official cps_http Nimble package

### DIFF
--- a/nim/cps-http/server.nimble
+++ b/nim/cps-http/server.nimble
@@ -4,4 +4,4 @@ description = "CPS HTTP implementation for web-frameworks"
 license = "MIT"
 
 requires "nim >= 2.0.0"
-requires "https://github.com/gabearro/cps-http >= 1.0 & <1.1"
+requires "cps_http >= 1.0 & < 1.1"


### PR DESCRIPTION
Targets #9670 and keeps its existing CPS adapter changes intact.

Now that the CPS packages are merged into Nim's official registry, this replaces the remaining direct GitHub requirement with the registered `cps_http` package name. The version range is unchanged.

Validation:
- generated the official multithreaded Docker manifest
- resolved `cps_http` and its CPS dependencies from a clean Nim 2.2 image
- built the benchmark server successfully
- passed the official route spec: 6 examples, 0 failures

This is intentionally a one-line diff so it does not duplicate #9670's removal of `build_with` or its reactor/configuration changes.