### PR TITLE
Update CPS HTTP multithreaded runtime

### DIFF
--- a/nim/cps-http/config.yaml
+++ b/nim/cps-http/config.yaml
@@ -1,12 +1,13 @@
 framework:
   github: gabearro/cps-http
+  website: github.com/gabearro/cps-http
   version: 1.0
   engines:
     - multithreaded
 
-# Each reactor thread owns its event loop, router, listener, and connections.
-# SO_REUSEPORT distributes accepts across the shard-local reactors without a
-# shared scheduler or cross-thread work on the HTTP data path.
+# The work-stealing runtime starts one I/O shard per worker. Each shard owns its
+# event loop, router, listener, and connections; SO_REUSEPORT distributes
+# accepts without putting a shared scheduler on the HTTP data path.
 language:
   engines:
     multithreaded:

--- a/nim/cps-http/server.nim
+++ b/nim/cps-http/server.nim
@@ -1,15 +1,8 @@
+import std/os
 import cps/runtime
-import cps/reactorpool
-import cps/io/tcp
-import cps/io/streams
+import cps/mt
 import cps/http/server/dsl
-import cps/http/server/http1
-
-proc startAccepting(listener: TcpListener, handler: HttpHandler) =
-  let config = HttpServerConfig()
-  listener.acceptEach(proc(client: TcpStream) =
-    discard handleHttp1Connection(client.AsyncStream, config, handler)
-  )
+import cps/http/server/server
 
 proc startShard(shardId: int) {.gcsafe.} =
   {.cast(gcsafe).}:
@@ -23,8 +16,23 @@ proc startShard(shardId: int) {.gcsafe.} =
       post "/user":
         respond 200
 
-    let listener = tcpListen("0.0.0.0", 3000, reusePort = true,
-                             deferAcceptSeconds = 1, noDelay = true)
-    startAccepting(listener, handler)
+    let server = newHttpServer(
+      handler,
+      host = "0.0.0.0",
+      port = 3000,
+      enableHttp2 = false,
+      reusePort = true,
+      tcpNoDelay = true
+    )
+    server.bindAndListen()
+    discard server.start()
 
-runReactorPool(startShard)
+proc main() =
+  let runtime = newMultiThreadRuntime()
+  setMainRuntime(runtime)
+  setCurrentRuntime(runtime)
+  runtime.startMtIoShards(startShard)
+  while true:
+    sleep(1000)
+
+main()

--- a/nim/cps-http/server.nimble
+++ b/nim/cps-http/server.nimble
@@ -1,7 +1,7 @@
-version = "1.0.1"
+version = "1.0.2"
 author = "Gabriel Arroyo"
 description = "CPS HTTP implementation for web-frameworks"
 license = "MIT"
 
 requires "nim >= 2.0.0"
-requires "cps_http >= 1.0 & < 1.1"
+requires "cps_http >= 1.0.4 & < 1.1"


### PR DESCRIPTION
## Updates

- replace the legacy `runReactorPool` adapter with `newMultiThreadRuntime` and per-worker I/O shards
- require CPS HTTP 1.0.4 so clean Docker builds include the released runtime and accept-lifecycle improvements <- im pretty sure the last run didn't pull the newest deps
- point the framework website to the CPS HTTP repository

## Validation

- generated and built the official `nim/cps-http/.Dockerfile.multithreaded`
- confirmed the build resolved `cps_http` 1.0.4, `cps_runtime` 1.1.3, `cps_tls` 1.0.4, and `cps_quic` 1.0.4
- validated `GET /`, `GET /user/0`, and `POST /user` from a separate Docker bridge-network client; all returned HTTP 200 with the expected bodies
- CPS runtime and HTTP test matrices pass under ARC, ORC, and AtomicARC