### PR TITLE
Benchmark over per-request connections again, and verify zrk's version

### DIFF
--- a/.tasks/config.rake
+++ b/.tasks/config.rake
@@ -131,12 +131,28 @@ def commands_for(language, framework, variant, provider = 'docker')
   # zrk >= the release carrying --closed (zoxy-io/zrk).
   duration = ENV.fetch('DURATION', '15s')
 
+  # --disable-keepalive (zrk >= 2.4.0) puts every request on its own TCP
+  # connection, restoring what oha's flag of the same name did before the move
+  # to zrk -- without it the numbers are not comparable to any run before
+  # 76ac1aed4.
+  #
+  # It has to be the flag and not `-H 'Connection: close'`: zrk decides whether
+  # to reuse a socket from the RESPONSE, so the header reconnects only against
+  # frameworks that honour it and leaves the ones that ignore it -- the
+  # httpbeast-derived Nim frameworks, the Workerman/Swoole PHP ones, agoo-c,
+  # may_minihttp, httpz, mist -- running at full keep-alive speed. Those are
+  # among the fastest entries here, so the header would flatter exactly the
+  # wrong ones. The flag closes from the client side regardless.
+  #
+  # Each result file records the mode it was produced under in its own
+  # config.disable_keepalive.
+
   hostname = File.join(directory, language, framework, "ip-#{variant}.txt")
   File.join(directory, language, framework, "cid-#{variant}.txt")
   File.join(File.dirname(__FILE__), 'memory_sampler.rb')
   zrk_path = 'zrk'
 
-  commands[:warmup] << "#{zrk_path} --plain -c 50 --closed -d 5s http://`cat #{hostname}`:3000/"
+  commands[:warmup] << "#{zrk_path} --plain -c 50 --closed --disable-keepalive -d 5s http://`cat #{hostname}`:3000/"
   commands[:test] << "ENGINE=#{variant} LANGUAGE=#{language} FRAMEWORK=#{framework} bundle exec rspec .spec"
 
   concurrencies.split(',').each do |concurrency|
@@ -149,7 +165,7 @@ def commands_for(language, framework, variant, provider = 'docker')
     routes.split(',').each do |route|
       method, uri = route.split(':')
       output = File.join(directory, language, framework, '.results', concurrency, "#{uri.tr('/', '_')}.json")
-      zrk_cmds << "#{zrk_path} --plain -c #{concurrency} --closed -d #{duration} -m #{method} --format json --output #{output} http://`cat #{hostname}`:3000#{uri}"
+      zrk_cmds << "#{zrk_path} --plain -c #{concurrency} --closed --disable-keepalive -d #{duration} -m #{method} --format json --output #{output} http://`cat #{hostname}`:3000#{uri}"
     end
 
     # Start memory sampler in background, run all zrk calls, then stop sampler

--- a/run.sh
+++ b/run.sh
@@ -4,14 +4,41 @@ BASEDIR=`pwd`
 # in this repo installs it. Without this check a missing zrk surfaces as a
 # "command not found" per framework, hours into a run, with empty .results and
 # a `make` that kept going -- so fail here instead, before the first build.
-if ! command -v zrk > /dev/null 2>&1; then
-	echo "zrk not found on PATH." >&2
+#
+# The version is checked too, not just the presence. A too-old zrk does not
+# fail loudly: it rejects the unknown flag per invocation, which is the same
+# "empty .results, make kept going" outcome the presence check exists to
+# prevent -- and the check used to claim a minimum it never enforced.
+ZRK_MIN=2.4.0  # --closed (2.2.0) and --disable-keepalive (2.4.0)
+
+zrk_install_help() {
 	echo "" >&2
 	echo "Install it with one of:" >&2
 	echo "  brew install zoxy-io/tap/zrk" >&2
 	echo "  https://github.com/zoxy-io/zrk/releases (static binaries)" >&2
+}
+
+if ! command -v zrk > /dev/null 2>&1; then
+	echo "zrk not found on PATH." >&2
+	zrk_install_help
 	echo "" >&2
-	echo "--closed (used by the collect targets) needs zrk >= 2.2.0." >&2
+	echo "The collect targets need zrk >= ${ZRK_MIN}." >&2
+	exit 1
+fi
+
+ZRK_VERSION=`zrk --version 2>/dev/null | awk '{print $2}'`
+if [ -z "$ZRK_VERSION" ]; then
+	echo "could not read a version from \`zrk --version\`." >&2
+	echo "Is the zrk on PATH really zoxy-io/zrk?" >&2
+	exit 1
+fi
+
+# sort -V puts the lower version first, so the minimum leading means it is met
+# (equal versions sort either way and both satisfy it).
+if [ "`printf '%s\n%s\n' "$ZRK_MIN" "$ZRK_VERSION" | sort -V | head -n1`" != "$ZRK_MIN" ]; then
+	echo "zrk ${ZRK_VERSION} is too old; the collect targets need >= ${ZRK_MIN}." >&2
+	echo "(The collect targets run --disable-keepalive, added in 2.4.0.)" >&2
+	zrk_install_help
 	exit 1
 fi
 


### PR DESCRIPTION
The move from oha to zrk (76ac1aed4) dropped --disable-keepalive without replacing it, because zrk had no equivalent. So every run since has been measured over reused connections while every run before it paid for a TCP connection per request, and the two are not comparable: throughput rose ~4x for frameworks that honour `Connection: close` and 130-165x for the 27 that ignore it -- the httpbeast-derived Nim frameworks, the Workerman/Swoole PHP ones, agoo-c, may_minihttp, httpz, mist -- which went from the bottom of the board to the top on a change in the load generator alone.

zrk 2.4.0 adds --disable-keepalive, so the collect targets use it. It has to be the flag rather than `-H 'Connection: close'`: zrk decides whether to reuse a socket from the RESPONSE, so the header reconnects only against frameworks that honour it and leaves the ones that ignore it -- exactly the group above -- running at full keep-alive speed. The flag closes from the client side regardless, so every framework pays the same price. Each result file records which mode produced it in its own config.disable_keepalive.

run.sh now checks zrk's version rather than only its presence. It already claimed a minimum it never enforced, and a too-old zrk fails the same way a missing one does: an unknown flag rejected per invocation, hours into a run, with empty .results and a make that kept going. Comparison is `sort -V`, so 2.10.0 counts as newer than 2.4.0.

---

- https://github.com/the-benchmarker/web-frameworks/pull/9668#issuecomment-5464597030