### PR TITLE
fulmine: drop the connection headers

### DIFF
--- a/javascript/fulmine/app.mjs
+++ b/javascript/fulmine/app.mjs
@@ -7,6 +7,9 @@ import express from 'fulmine.js';
 const app = express({ cluster: 'auto' });
 
 app.set('etag', false);
+// keep-alive is implicit on HTTP/1.1, so the Connection and Keep-Alive headers carry no
+// information: off, which is also what the engine itself answers.
+app.set('connection headers', false);
 
 app.get('/', function (req, res) {
   res.send('');


### PR DESCRIPTION
fulmine answers every response with `Connection: keep-alive` and `Keep-Alive: timeout=10` because Express does. On HTTP/1.1 keep-alive is implicit, so the two headers add about 50 bytes and two header writes per response without telling the client anything new. The framework has a setting to turn them off, this PR sets it, like `etag` already is.

`Connection: close` is still sent when the client asks for it, verified on the three routes.
