### PR TITLE
Fix the website and version fields carrying over from the framework merged before

### DIFF
--- a/.spec/helpers_spec.rb
+++ b/.spec/helpers_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../.tasks/helpers'
+
+RSpec.describe Hash do
+  describe '#recursive_merge' do
+    it 'leaves the receiver alone' do
+      main = { 'framework' => { 'version' => 1 } }
+      main.recursive_merge('framework' => { 'website' => 'first.example' })
+
+      expect(main).to eq('framework' => { 'version' => 1 })
+    end
+
+    # .tasks/db.rake merges into the same main config once per framework, so a
+    # value read here has to come from the hash passed in and from nothing else.
+    it 'does not carry a value over to the next merge' do
+      main = {}
+      first = main.recursive_merge('framework' => { 'website' => 'first.example' })
+      second = main.recursive_merge('framework' => { 'version' => 2 })
+
+      expect(first.dig('framework', 'website')).to eq('first.example')
+      expect(second.dig('framework', 'website')).to be_nil
+    end
+
+    it 'merges nested hashes' do
+      config = { 'framework' => { 'version' => 1, 'engines' => { 'node' => 'a' } } }
+
+      expect(config.recursive_merge('framework' => { 'engines' => { 'node' => 'b', 'bun' => 'c' } }))
+        .to eq('framework' => { 'version' => 1, 'engines' => { 'node' => 'b', 'bun' => 'c' } })
+    end
+  end
+end

--- a/.tasks/helpers.rb
+++ b/.tasks/helpers.rb
@@ -8,7 +8,11 @@ def normalize_shell(shell)
 end
 
 class Hash
+  # Returns a new hash and leaves the receiver alone. With `merge!` the receiver
+  # kept every key it was ever merged with, so in .tasks/db.rake, where the same
+  # main config is merged once per framework, a framework whose config.yaml does
+  # not set a key got the value of the framework merged before it.
   def recursive_merge(hash)
-    merge!(hash) { |_, old, new| old.instance_of?(Hash) ? old.recursive_merge(new) : new }
+    merge(hash) { |_, old, new| old.instance_of?(Hash) ? old.recursive_merge(new) : new }
   end
 end

--- a/v/vanilla_epoll/config.yaml
+++ b/v/vanilla_epoll/config.yaml
@@ -1,5 +1,6 @@
 framework:
   github: vlang/v
+  version: 1822cbb4b5316f433df4805bb68560fadd4df385
 
   # Install as the `vanilla` module (import vanilla.http_server). `v install <url>`
   # now namespaces by owner (~/.vmodules/enghitalo/vanilla), so clone to the

--- a/v/vanilla_io_uring/config.yaml
+++ b/v/vanilla_io_uring/config.yaml
@@ -1,5 +1,6 @@
 framework:
   github: vlang/v
+  version: 1822cbb4b5316f433df4805bb68560fadd4df385
 
   # Install as the `vanilla` module (import vanilla.http_server). `v install <url>`
   # now namespaces by owner (~/.vmodules/enghitalo/vanilla), so clone to the

--- a/zig/httpz/config.yaml
+++ b/zig/httpz/config.yaml
@@ -1,2 +1,3 @@
 framework:
   github: karlseguin/http.zig
+  version: 52eb187cff75e168316b44480cd9f0fae26a1c5e


### PR DESCRIPTION
`Hash#recursive_merge` in `.tasks/helpers.rb` uses `merge!`, so it modifies the receiver. `.tasks/db.rake` loads `main_config` once and merges it with every framework in the loop, so `main_config` keeps every key it has ever seen and a framework whose `config.yaml` does not set a key gets the value of the framework merged before it, in alphabetical order.

In the published `data.min.json` this makes **230 of 358 `website` fields wrong**: 64 point at another framework's site (`clojure/donkey` at coast.swlkr.com, `cpp/oatpp` at luminusweb.com, `javascript/fulmine` at foxify.js.org), and 203 more are `http://` instead of `https://` because one `unsecure:` framework poisons all the rest. `version` leaks too: `zig/httpz` and `v/vanilla_epoll` publish `24120e7a...`, which is the V compiler pinned by `v/veb`.

The fix is `merge` instead of `merge!`. Two frameworks then had no version of their own, so I added the one each of them already pins: `52eb187c...` from `zig/httpz/build.zig.zon`, `1822cbb4...` from the `download` step of the two `v/vanilla_*`. Change them if you would rather have something else there.

Checked with ruby 3.4 in a container: `rake config` writes the same 847 Dockerfiles and Makefiles before and after, so nothing about the builds moves, and the three added `version:` keys do not change a manifest either. `.spec/helpers_spec.rb` is new, it fails on two of three examples without the fix.

fix https://github.com/the-benchmarker/web-frameworks/issues/9715