### PR TITLE
Update cps-http benchmark to 2.x

### DIFF
--- a/nim/cps-http/config.yaml
+++ b/nim/cps-http/config.yaml
@@ -1,7 +1,7 @@
 framework:
   github: gabearro/cps-http
   website: github.com/gabearro/cps-http
-  version: 1.0
+  version: 2.0
   engines:
     - multithreaded
 

--- a/nim/cps-http/server.nimble
+++ b/nim/cps-http/server.nimble
@@ -1,7 +1,7 @@
-version = "1.0.2"
+version = "2.0.1"
 author = "Gabriel Arroyo"
 description = "CPS HTTP implementation for web-frameworks"
 license = "MIT"
 
 requires "nim >= 2.0.0"
-requires "cps_http >= 1.0.4 & < 1.1"
+requires "cps_http >= 2.0.1 & < 3.0.0"


### PR DESCRIPTION
## Updates

- report the CPS HTTP framework as version 2.0
- require the latest released `cps_http` baseline, 2.0.1
- allow compatible updates throughout the 2.x line while keeping 3.0 as the next reviewed breaking boundary

`cps_http` 2.0.1 pins `cps_runtime`, `cps_tls`, and `cps_quic` to the matching 2.0.1 releases, so the benchmark installs a consistent CPS ecosystem.

## Validation

- generated `nim/cps-http/.Dockerfile.multithreaded` using the repository's `rake config` task
- built the exact generated Docker image successfully against the public Nimble package index
- verified from a separate Docker-network client:
  - `GET /` returns HTTP 200 with an empty body
  - `GET /user/0` returns HTTP 200 with body `0`
  - `POST /user` returns HTTP 200 with an empty body

## Benchmark-round context

Commit `cf60f1e` contains results from 15-second closed-loop `zrk` runs at 64, 256, and 512 persistent connections, following a 5-second 50-connection warmup. The three recorded routes are `GET /`, `GET /user/0`, and `POST /user`; keep-alive remains enabled. This dependency window lets the next round exercise the released 2.x implementation under those current settings.
