### PR TITLE
Add cwist

### DIFF
--- a/c/cwist/config.yaml
+++ b/c/cwist/config.yaml
@@ -1,0 +1,39 @@
+# the-benchmarker/web-frameworks implementation config.
+# This file is maintained here and mirrored into the benchmark repository as
+# `c/cwist/config.yaml`. The matching application source is `main.c`.
+
+framework:
+  github: Religiya-Serdtsa/CWIST
+  version: 3.2
+
+  build_deps:
+    - git
+    - cmake
+    - pkg-config
+    - libzstd-dev
+    - libbrotli-dev
+    - libcurl4-openssl-dev
+    - libnghttp2-dev
+
+  download:
+    - git clone --depth 1 --branch v3.2 --recurse-submodules --shallow-submodules https://github.com/Religiya-Serdtsa/CWIST.git cwist
+
+  build:
+    - cd cwist && make -j$(nproc)
+    - gcc -O2 -Icwist/include -o cwist_bench main.c
+        -Lcwist
+        -Lcwist/lib/boringssl/build
+        -Lcwist/lib/lsquic/build/src/liblsquic
+        -Lcwist/lib/libttak/lib
+        -Lcwist/lib/cnats/build/lib
+        -Lcwist/lib/cjson
+        -Lcwist/lib/uriparser/build
+        -lcwist -lnats_static -lttak -lcjson -luriparser -llsquic
+        -lssl -lcrypto
+        $(pkg-config --libs libcurl libnghttp2 libbrotlienc libbrotlicommon libbrotlidec libzstd)
+        -lz -ldl -lpthread -lm -lstdc++
+
+  binaries:
+    - cwist_bench
+
+  command: /opt/web/cwist_bench

--- a/c/cwist/config.yaml
+++ b/c/cwist/config.yaml
@@ -21,7 +21,7 @@ framework:
 
   build:
     - cd cwist && make -j$(nproc)
-    - gcc -O2 -Icwist/include -o cwist_bench main.c
+    - gcc -O2 -Icwist/include -Icwist/lib -o cwist_bench main.c
         -Lcwist
         -Lcwist/lib/boringssl/build
         -Lcwist/lib/lsquic/build/src/liblsquic

--- a/c/cwist/config.yaml
+++ b/c/cwist/config.yaml
@@ -4,10 +4,11 @@
 
 framework:
   github: Religiya-Serdtsa/CWIST
-  version: 3.2
+  version: 3.3
 
   build_deps:
     - git
+    - ca-certificates
     - cmake
     - pkg-config
     - libzstd-dev
@@ -16,7 +17,7 @@ framework:
     - libnghttp2-dev
 
   download:
-    - git clone --depth 1 --branch v3.2 --recurse-submodules --shallow-submodules https://github.com/Religiya-Serdtsa/CWIST.git cwist
+    - git clone --depth 1 --branch v3.3 --recurse-submodules --shallow-submodules https://github.com/Religiya-Serdtsa/CWIST.git cwist
 
   build:
     - cd cwist && make -j$(nproc)

--- a/c/cwist/config.yaml
+++ b/c/cwist/config.yaml
@@ -2,6 +2,11 @@
 # This file is maintained here and mirrored into the benchmark repository as
 # `c/cwist/config.yaml`. The matching application source is `main.c`.
 
+language:
+  engines:
+    default:
+      command: /opt/web/cwist_bench
+
 framework:
   github: Religiya-Serdtsa/CWIST
   version: 3.3
@@ -37,4 +42,3 @@ framework:
   binaries:
     - cwist_bench
 
-  command: /opt/web/cwist_bench

--- a/c/cwist/main.c
+++ b/c/cwist/main.c
@@ -1,0 +1,31 @@
+/**
+ * @file main.c
+ * @brief the-benchmarker/web-frameworks contract app.
+ *
+ *   GET  /         -> 2xx, empty body
+ *   GET  /user/:id -> 2xx, body is the id path parameter
+ *   POST /user     -> 2xx, empty body
+ */
+
+#include <cwist/app.h>
+#include <cwist/net/http/query.h>
+
+static void empty(cwist_http_request *req, cwist_http_response *res) {
+    (void)req;
+    (void)res;
+}
+
+static void user_id(cwist_http_request *req, cwist_http_response *res) {
+    const char *id = cwist_query_map_get(req->path_params, "id");
+    if (id) cwist_sstring_assign(res->body, id);
+}
+
+int main(void) {
+    cwist_app *app = cwist_app_create();
+    cwist_app_get(app, "/", empty);
+    cwist_app_get(app, "/user/:id", user_id);
+    cwist_app_post(app, "/user", empty);
+    cwist_app_listen(app, 3000);
+    cwist_app_destroy(app);
+    return 0;
+}


### PR DESCRIPTION
Adds [cwist](https://github.com/Religiya-Serdtsa/CWIST), a C17 web framework and application server with HTTP/1.1, HTTP/2, HTTP/3 (QUIC), and WebSocket support. I maintain the framework.

The implementation is the usual three routes from the contract (`GET /`, `GET /user/:id`, `POST /user`) on port 3000. The build clones the framework at tag v3.3 with its vendored dependencies (BoringSSL, lsquic, libttak, SQLite) and links statically, so the resulting container has no runtime requirements beyond libc.

One thing worth flagging: the vendored build (BoringSSL in particular) makes the image build slower than most C entries here. If that turns out to be a problem for CI, I can look at trimming the dependency set for this target.