### PR TITLE
Fix cwist build: missing vendored include paths (sqlite3.h not found)

### DIFF
--- a/c/cwist/config.yaml
+++ b/c/cwist/config.yaml
@@ -26,7 +26,10 @@ framework:
 
   build:
     - cd cwist && make -j$(nproc)
-    - gcc -O2 -Icwist/include -Icwist/lib -o cwist_bench main.c
+    - gcc -O2 -Icwist/include -Icwist/lib -Icwist/lib/libttak/include -Icwist/lib/cjson
+        -Icwist/lib/sqlite3 -Icwist/lib/uriparser/include -Icwist/lib/cnats/src
+        -Icwist/lib/boringssl/include -Icwist/lib/lsquic/include -Icwist/lib/multipart-parser-c
+        -o cwist_bench main.c
         -Lcwist
         -Lcwist/lib/boringssl/build
         -Lcwist/lib/lsquic/build/src/liblsquic


### PR DESCRIPTION
Fixes the build failure reported on #9745: `cwist/include/cwist/core/db/sql.h:9:10: fatal error: sqlite3.h: No such file or directory`.

## Cause

The build command for `main.c` only passed `-Icwist/include -Icwist/lib`, which doesn't cover cwist's vendored dependency subdirectories. `cwist/app.h` transitively includes `<sqlite3.h>` (vendored at `lib/sqlite3/`), then `<ttak/mem_tree/mem_tree.h>` (`lib/libttak/include/`) and `<openssl/ssl.h>` (`lib/boringssl/include/`, since the binary statically links BoringSSL rather than system OpenSSL) — none of these are reachable from the two `-I` flags that were there. `sql.h` is the first of these hit in `app.h`'s include order, hence the specific error.

I reproduced this locally: it silently "worked" on my machine only because I have `libsqlite3-dev` installed system-wide, so gcc fell back to `/usr/local/include/sqlite3.h" instead of the vendored copy — masking the missing include path. A clean container without that package (as build_deps here doesn't install it) hits the error directly, matching the report.

## Fix

Add the missing vendored include paths, mirroring the same list cwist's own `Makefile` uses (`INCLUDE_PATHS`) so nothing else in the same include chain breaks after this.

I maintain the cwist framework (v3.3 tag was re-verified against this exact build command).