### PR TITLE
Add Next.js benchmark

### DIFF
--- a/javascript/nextjs/.gitignore
+++ b/javascript/nextjs/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+package-lock.json

--- a/javascript/nextjs/app.mjs
+++ b/javascript/nextjs/app.mjs
@@ -1,0 +1,7 @@
+import { createServer } from 'node:http';
+import next from 'next';
+
+const app = next({ dev: false });
+await app.prepare();
+
+createServer(app.getRequestHandler()).listen(3000, '0.0.0.0');

--- a/javascript/nextjs/app/route.js
+++ b/javascript/nextjs/app/route.js
@@ -1,0 +1,5 @@
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return new Response(null);
+}

--- a/javascript/nextjs/app/user/[id]/route.js
+++ b/javascript/nextjs/app/user/[id]/route.js
@@ -1,0 +1,6 @@
+export const dynamic = 'force-dynamic';
+
+export async function GET(request, { params }) {
+  const { id } = await params;
+  return new Response(id);
+}

--- a/javascript/nextjs/app/user/route.js
+++ b/javascript/nextjs/app/user/route.js
@@ -1,0 +1,3 @@
+export function POST() {
+  return new Response(null);
+}

--- a/javascript/nextjs/cluster.mjs
+++ b/javascript/nextjs/cluster.mjs
@@ -1,0 +1,20 @@
+import cluster from 'node:cluster';
+import { availableParallelism } from 'node:os';
+
+const numCpus = availableParallelism();
+
+if (cluster.isPrimary) {
+  for (let i = 0; i < numCpus; i++) {
+    cluster.fork();
+  }
+
+  function shutdown() {
+    cluster.disconnect(() => process.exit(0));
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+} else {
+  await import(`./${process.env.NODE_APP}`);
+  console.log(`Worker ${process.pid} started`);
+}

--- a/javascript/nextjs/config.yaml
+++ b/javascript/nextjs/config.yaml
@@ -1,0 +1,13 @@
+framework:
+  website: nextjs.org
+  github: vercel/next.js
+  version: 16.3
+
+  files:
+    - app
+    - app.mjs
+    - cluster.mjs
+    - package.json
+
+  bootstrap:
+    - NEXT_TELEMETRY_DISABLED=1 npm run build

--- a/javascript/nextjs/package.json
+++ b/javascript/nextjs/package.json
@@ -1,0 +1,11 @@
+{
+  "type": "module",
+  "scripts": {
+    "build": "next build"
+  },
+  "dependencies": {
+    "next": "~16.3.4",
+    "react": "~19.2.8",
+    "react-dom": "~19.2.8"
+  }
+}


### PR DESCRIPTION
Adds Next.js 16.3 App Router handlers for `GET /`, `GET /user/:id`, and `POST /user`, returning the required status codes and response bodies directly at the root paths.

The generated Node Docker image builds the application in production mode and uses the same cluster launcher as the existing Node implementations. Requests go through Next.js's request handler; GET routes explicitly use dynamic execution to avoid benchmarking prerendered responses. The application directory is copied as a directory so the `[id]` route survives Docker's source-path globbing.

Validation:

- Generated the Dockerfile with `bundle exec rake config` and built it using the repository's `node:26-slim` base image (Node 26.8.1, Next.js 16.3.4).
- Ran the existing `bundle exec rspec .spec` suite against the container: 9 examples, 0 failures.
- Verified two cluster workers, 60 concurrent requests, numeric/string/URL-encoded IDs, and absence of the benchmark routes from the prerender manifest.
- Confirmed CI discovers `javascript/nextjs` with the Node engine.

Closes #7361.
