### PR TITLE
Add peregrine (Swift-based ASGI/WSGI server): raw ASGI/WSGI, FastAPI and Django

### DIFF
--- a/python/config.yaml
+++ b/python/config.yaml
@@ -93,6 +93,20 @@ language:
           --port 3000 \
           --workers $(nproc) \
           ${PYTHON_APP}
+    peregrine:
+      bootstrap:
+        - pip install 'peregrine-server>=1.0,<1.1'
+      environment:
+        INTERFACE: asgi
+        PYTHON_APP: server:app
+      command: >
+        peregrine \
+          --log-level error \
+          --protocol ${INTERFACE} \
+          --host 0.0.0.0 \
+          --port 3000 \
+          --workers $(nproc) \
+          ${PYTHON_APP}
 
 framework:
   engines:

--- a/python/peregrine-asgi/config.yaml
+++ b/python/peregrine-asgi/config.yaml
@@ -1,0 +1,6 @@
+framework:
+  github: grepjava/peregrine
+  version: 1.0
+
+  engines:
+    - peregrine

--- a/python/peregrine-asgi/pyproject.toml
+++ b/python/peregrine-asgi/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+build-backend = "flit_core.buildapi"
+requires = ["flit_core"]
+
+[project]
+name='server'
+version = '1.0.0'
+description = "Simple benchmark implementation"
+dependencies = []

--- a/python/peregrine-asgi/server.py
+++ b/python/peregrine-asgi/server.py
@@ -1,0 +1,32 @@
+async def app(scope, receive, send):
+    if scope["type"] != "http":
+        return
+
+    path = scope["path"]
+    method = scope["method"]
+
+    if method == "GET":
+        if path == "/":
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b""})
+            return
+
+        if path.startswith("/user/"):
+            body = path[6:].encode()
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [[b"content-type", b"text/plain; charset=utf-8"]],
+                }
+            )
+            await send({"type": "http.response.body", "body": body})
+            return
+
+    elif method == "POST" and path == "/user":
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+        return
+
+    await send({"type": "http.response.start", "status": 404, "headers": []})
+    await send({"type": "http.response.body", "body": b""})

--- a/python/peregrine-django/app/asgi.py
+++ b/python/peregrine-django/app/asgi.py
@@ -1,0 +1,7 @@
+import os
+
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+application = get_asgi_application()

--- a/python/peregrine-django/app/urls.py
+++ b/python/peregrine-django/app/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path(r"", views.index),
+    path(r"user/<int:id>", views.get_user),
+    path(r"user", views.create_user),
+]

--- a/python/peregrine-django/app/views.py
+++ b/python/peregrine-django/app/views.py
@@ -1,0 +1,13 @@
+from django.http import HttpResponse
+
+
+def index(request):
+    return HttpResponse(status=200)
+
+
+def get_user(request, id):
+    return HttpResponse(id)
+
+
+def create_user(request):
+    return HttpResponse(status=200)

--- a/python/peregrine-django/app/wsgi.py
+++ b/python/peregrine-django/app/wsgi.py
@@ -1,0 +1,16 @@
+"""
+WSGI config for bl project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
+"""
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+application = get_wsgi_application()

--- a/python/peregrine-django/config.yaml
+++ b/python/peregrine-django/config.yaml
@@ -1,0 +1,13 @@
+framework:
+  website: djangoproject.com
+  version: 6.1
+
+  engines:
+    - peregrine
+
+language:
+  engines:
+    peregrine:
+      environment:
+        INTERFACE: wsgi
+        PYTHON_APP: app.wsgi:application

--- a/python/peregrine-django/pyproject.toml
+++ b/python/peregrine-django/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+build-backend = "flit_core.buildapi"
+requires = ["flit_core >=3.2,<4"]
+
+[project]
+name='app.wsgi'
+version = '1.0.0'
+description = "Simple benchmark implementation"
+dependencies = ["django>=6.1,<6.2"]

--- a/python/peregrine-django/settings.py
+++ b/python/peregrine-django/settings.py
@@ -1,0 +1,85 @@
+import os
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = "3f51&0k++@_2u24_v@f)_-n7a0y&hc8^wmru)q^_flty9%!@er"
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = False
+
+ALLOWED_HOSTS = ["127.0.0.1", "::1", "localhost"]
+ALLOWED_HOSTS += ["172.17.%s.%s" % (i, j) for i in range(256) for j in range(256)]
+
+
+# Application definition
+
+INSTALLED_APPS = []
+
+MIDDLEWARE = []
+
+ROOT_URLCONF = "app.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ]
+        },
+    }
+]
+
+WSGI_APPLICATION = "app.wsgi.application"
+
+
+# Database
+# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+    }
+}
+
+
+# Password validation
+# https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+    },
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
+]
+
+
+# Internationalization
+# https://docs.djangoproject.com/en/1.11/topics/i18n/
+
+LANGUAGE_CODE = "en-us"
+
+TIME_ZONE = "UTC"
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/1.11/howto/static-files/
+
+STATIC_URL = "/static/"

--- a/python/peregrine-fastapi/config.yaml
+++ b/python/peregrine-fastapi/config.yaml
@@ -1,0 +1,6 @@
+framework:
+  website: fastapi.tiangolo.com
+  version: 0.141
+
+  engines:
+    - peregrine

--- a/python/peregrine-fastapi/pyproject.toml
+++ b/python/peregrine-fastapi/pyproject.toml
@@ -1,0 +1,11 @@
+
+[build-system]
+build-backend = "flit_core.buildapi"
+requires = ["flit_core"]
+
+[project]
+name='server'
+version = '1.0.0'
+description = "Simple benchmark implementation"
+dependencies = ["fastapi>=0.141,<0.142"]
+

--- a/python/peregrine-fastapi/server.py
+++ b/python/peregrine-fastapi/server.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+from starlette.responses import PlainTextResponse
+
+app = FastAPI()
+
+
+@app.get("/")
+async def index():
+    return PlainTextResponse(content="")
+
+
+@app.get("/user/{id}")
+async def get_user(id: int):
+    return PlainTextResponse(content=f"{id}".encode())
+
+
+@app.post("/user")
+async def create_user():
+    return PlainTextResponse(content="")

--- a/python/peregrine-wsgi/config.yaml
+++ b/python/peregrine-wsgi/config.yaml
@@ -1,0 +1,12 @@
+framework:
+  github: grepjava/peregrine
+  version: 1.0
+
+  engines:
+    - peregrine
+
+language:
+  engines:
+    peregrine:
+      environment:
+        INTERFACE: wsgi

--- a/python/peregrine-wsgi/pyproject.toml
+++ b/python/peregrine-wsgi/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+build-backend = "flit_core.buildapi"
+requires = ["flit_core"]
+
+[project]
+name='server'
+version = '1.0.0'
+description = "Simple benchmark implementation"
+dependencies = []

--- a/python/peregrine-wsgi/server.py
+++ b/python/peregrine-wsgi/server.py
@@ -1,0 +1,22 @@
+_PLAIN_TEXT = [("Content-Type", "text/plain; charset=utf-8")]
+
+
+def app(environ, start_response):
+    path = environ["PATH_INFO"]
+    method = environ["REQUEST_METHOD"]
+
+    if method == "GET":
+        if path == "/":
+            start_response("200 OK", [])
+            return [b""]
+
+        if path.startswith("/user/"):
+            start_response("200 OK", _PLAIN_TEXT)
+            return [path[6:].encode()]
+
+    elif method == "POST" and path == "/user":
+        start_response("200 OK", [])
+        return [b""]
+
+    start_response("404 Not Found", [])
+    return [b""]


### PR DESCRIPTION
Adds [peregrine](https://github.com/grepjava/peregrine), a Python ASGI/WSGI server written in Swift 6. It embeds CPython in-process rather than talking to it over a socket, so there is no second process and no serialisation step between the HTTP parser and the application.

## What is here

| Directory | Interface | Application |
|---|---|---|
| `python/peregrine-asgi` | ASGI | bare ASGI callable |
| `python/peregrine-wsgi` | WSGI | bare WSGI callable |
| `python/peregrine-fastapi` | ASGI | the FastAPI app from `python/fastapi`, unchanged |
| `python/peregrine-django` | WSGI | the Django app from `python/django`, unchanged |

Plus one `peregrine` engine in `python/config.yaml`.

The FastAPI and Django sources are copied verbatim from the existing entries, so between `python/fastapi` and `python/peregrine-fastapi` the only variable is the server.

## Notes

- **Nothing is compiled at image build time.** `peregrine-server` 1.0.0 publishes `manylinux_2_39` wheels for cp311 through cp314, including cp314t; `python:3.14-slim` is glibc 2.41, so the engine bootstrap is a plain `pip install` of a prebuilt wheel.
- **`--protocol` is set explicitly** per implementation rather than left to peregrine's auto-detection, so the interface under test is the one the directory names.
- `--log-level error` matches what the other Python engines do with their own quiet flags.

## Verification

`bundle exec rake config` generates all four manifests cleanly. Each image was then built and checked against the benchmark contract:

```
################ peregrine-asgi ################
GET  /          -> 200 body=''
GET  /user/0    -> 200 body='0'
POST /user      -> 200 body=''
RESULT peregrine-asgi: PASS

################ peregrine-wsgi ################
GET  /          -> 200 body=''
GET  /user/0    -> 200 body='0'
POST /user      -> 200 body=''
RESULT peregrine-wsgi: PASS

################ peregrine-fastapi ################
GET  /          -> 200 body=''
GET  /user/0    -> 200 body='0'
POST /user      -> 200 body=''
RESULT peregrine-fastapi: PASS

################ peregrine-django ################
GET  /          -> 200 body=''
GET  /user/0    -> 200 body='0'
POST /user      -> 200 body=''
RESULT peregrine-django: PASS

OVERALL: ALL PASS
```

No benchmarks were run; that is CI's and the maintainers' hardware, not mine.

## One question on shape

The obvious alternative for the last two is to add `peregrine` to the `engines:` list of the existing `python/fastapi` and `python/django` entries instead of giving them their own directories. I went with directories because `ci.rake`'s `matrix_for` and `run.sh` both take `engines&.first`, so an engine appended to an existing list would be neither built in CI nor benchmarked — it would be config that never runs.

Happy to reshape it either way if you would rather these lived as engines on the existing entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
